### PR TITLE
chore(ci): wire Claude /code-review on PRs

### DIFF
--- a/.claude/marketplace/.claude-plugin/marketplace.json
+++ b/.claude/marketplace/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "like-spotify-fork-plugins",
+  "owner": {
+    "name": "Osasuwu",
+    "email": "petrkudr2@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "code-review",
+      "description": "Code-review plugin (Osasuwu fork of anthropics/claude-plugins-official).",
+      "author": {
+        "name": "Osasuwu (fork of Anthropic plugin)"
+      },
+      "category": "productivity",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/Osasuwu/claude-plugins-official.git",
+        "path": "plugins/code-review",
+        "ref": "main"
+      },
+      "homepage": "https://github.com/Osasuwu/claude-plugins-official/tree/main/plugins/code-review"
+    }
+  ]
+}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,60 @@
+name: Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review
+        required: true
+        type: string
+
+jobs:
+  review:
+    # Skip fork PRs (untrusted code on main runner) and Dependabot.
+    # Draft PRs are skipped at the eligibility check inside the plugin.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run /code-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: ./.claude/marketplace
+          plugins: code-review@like-spotify-fork-plugins
+          prompt: |
+            Run /code-review for PR #${{ steps.pr.outputs.number }} in repo ${{ github.repository }}.
+
+            The /code-review slash command is provided by the code-review plugin
+            (loaded via the action's plugins input). Follow its instructions
+            verbatim — eligibility check, guideline-file gather, parallel
+            reviewers, confidence scoring, post comment.
+
+            This is plugin invocation only — do NOT load any user-level memory
+            or call MCP memory tools (not available in this runner).
+          claude_args: |
+            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(flutter analyze:*),Bash(dart analyze:*),Bash(python -m py_compile:*),Bash(bash -n:*),Bash(node --check:*)"


### PR DESCRIPTION
## Summary

Wires up `/code-review` to run on every PR, posting a review comment.

- `.github/workflows/code-review.yml` — triggers on PR open/sync/reopen/ready, plus `workflow_dispatch` with PR number input
- `.claude/marketplace/.claude-plugin/marketplace.json` — points to Osasuwu's code-review plugin fork

Adapted from jarvis — read-only, no auto-commit.

## Required before merge

Repo secret `CLAUDE_CODE_OAUTH_TOKEN` must be set:

```bash
gh secret set CLAUDE_CODE_OAUTH_TOKEN -R Osasuwu/like_spotify_mobile_app
# paste the same token used in jarvis (gh secret list -R Osasuwu/jarvis confirms it exists there)
```

If the secret is missing, the workflow runs but the action step fails — harmless, just a red check on PRs.

## Not in this PR

**Copilot auto-fix response workflow** (`copilot-review-response.yml` in jarvis) — uses `claude --dangerously-skip-permissions` + auto-commit + auto-push, gated by a safety-critical-paths block that has no analog in this repo (no `mcp-memory/`, no `SOUL.md`, no `.mcp.json`). Hold for separate decision: either define a safety gate appropriate for this repo (e.g. block `pubspec.yaml`, `android/app/build.gradle`, `.env*`, `lib/data/spotify/`) or stay manual on Copilot reviews.

**Copilot reviewer itself** — needs to be enabled in repo Settings → Code & automation → Code review (UI action). On free accounts, auto-review requires Copilot Pro+; otherwise a reviewer can request it manually per PR.

## Test plan

- [ ] Owner sets `CLAUDE_CODE_OAUTH_TOKEN` secret
- [ ] Merge this PR
- [ ] Open the next PR (e.g. #31 design review) and confirm Claude posts a review comment
- [ ] Decide on Copilot wiring shape, open follow-up if wanted