### PR TITLE
chore: drop duplicate like_spotify_launcher.py at repo root

### DIFF
--- a/like_spotify_launcher.py
+++ b/like_spotify_launcher.py
@@ -1,6 +1,0 @@
-"""PyInstaller entry target — keeps the spec workflow independent of console_scripts."""
-
-from like_spotify.hosts.tray import main
-
-if __name__ == "__main__":
-    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- PR #33 already shipped `tools/like_spotify_launcher.py` as the PyInstaller entry target.
- The fix-up commit on #33 added a second copy at the repo root because the original was missed during a root-level `ls`.
- The `.spec` resolves its script path relative to its own directory, so only the `tools/` copy is ever consumed — the root file was dead.

## Test plan

- [x] `rm -rf dist build && python -m PyInstaller --noconfirm tools/LikeSpotify.spec` → `dist/LikeSpotify.exe` produced (~20 MB), no missing-script error
- [x] No other refs to root path: `grep -RIn like_spotify_launcher` shows only the `tools/` copy + spec line referencing relative name

🤖 Generated with [Claude Code](https://claude.com/claude-code)