### PR TITLE
feat(desktop): backfill mechanic — first-encounter +2 for already-liked tracks (closes #24)

### DIFF
--- a/docs/supabase-setup.sql
+++ b/docs/supabase-setup.sql
@@ -1,0 +1,52 @@
+-- Like Spotify — Supabase schema for the cross-device like counter.
+--
+-- Fully idempotent: safe on fresh projects and on existing ones being
+-- upgraded for the #24 backfill mechanic. Run in the Supabase SQL Editor.
+
+-- ── Table ───────────────────────────────────────────────────────────
+create table if not exists public.track_likes (
+    user_id    text not null,
+    track_id   text not null,
+    count      integer not null default 0,
+    -- #24: marks rows where the first encounter found the track already in
+    -- Spotify's Liked Songs (we treat that first encounter as count=2).
+    -- Older rows keep the default `false` — no retroactive backfill.
+    backfilled boolean not null default false,
+    updated_at timestamptz not null default now(),
+    primary key (user_id, track_id)
+);
+
+alter table public.track_likes
+    add column if not exists backfilled boolean not null default false;
+
+-- ── RPC ────────────────────────────────────────────────────────────
+-- p_was_already_liked is the Spotify "already in Liked Songs" signal.
+--   row absent → INSERT count = 2 if true else 1; backfilled mirrors flag.
+--   row present → UPDATE count = count + 1; backfilled untouched.
+create or replace function public.increment_track_like(
+    p_user_id            text,
+    p_track_id           text,
+    p_was_already_liked  boolean default false
+)
+returns integer
+language plpgsql
+as $$
+declare
+    new_count integer;
+begin
+    insert into public.track_likes (user_id, track_id, count, backfilled, updated_at)
+    values (
+        p_user_id,
+        p_track_id,
+        case when p_was_already_liked then 2 else 1 end,
+        p_was_already_liked,
+        now()
+    )
+    on conflict (user_id, track_id) do update
+        set count      = public.track_likes.count + 1,
+            updated_at = now()
+    returning count into new_count;
+
+    return new_count;
+end;
+$$;

--- a/like_spotify/core/music_provider.py
+++ b/like_spotify/core/music_provider.py
@@ -17,6 +17,14 @@ class MusicProvider(ABC):
     async def like(self, track: CurrentTrack) -> None: ...
 
     @abstractmethod
+    async def is_liked(self, track: CurrentTrack) -> bool:
+        """True iff the user already had this track in their liked collection.
+
+        Read before `like()` to power the #24 backfill: first encounter of
+        a pre-existing like counts as 2. Cheap O(1) lookup is expected.
+        """
+
+    @abstractmethod
     async def user_id(self) -> str:
         """Stable per-user id. Storage keys against it.
 

--- a/like_spotify/core/pipeline.py
+++ b/like_spotify/core/pipeline.py
@@ -11,10 +11,15 @@ class Pipeline:
     """Composes a MusicProvider + optional Storage with feedback hooks.
 
     Tracer bullet (#21): currently_playing -> like -> feedback.
-    #22 adds Storage: after a successful like, increment a per-(user, track)
+    #22 added Storage: after a successful like, increment a per-(user, track)
     counter; surface the new count in feedback. Storage failure must NOT
-    fail the like — it's a soft signal, the host shows "Liked" without a
-    count. PreLikeActions / PostLikeActions plug in here in #23.
+    fail the like — soft signal, host shows "Liked" without a count.
+    #24 added backfill: when Storage is wired, peek at the provider's
+    `is_liked` *before* writing the like, then pass the flag to
+    `Storage.increment`. The backend treats first-encounter of an
+    already-liked track as count=2 (idempotent — flag only matters on
+    the INSERT).
+    PreLikeActions / PostLikeActions plug in here in #23.
     """
 
     def __init__(
@@ -39,6 +44,16 @@ class Pipeline:
             return
 
         ctx = LikeContext(track=track, music_provider=self._provider)
+
+        # Backfill probe: only worth the extra API call when Storage is wired.
+        # Soft fail to False — we'd rather miss a +1 backfill than double-count.
+        was_already_liked = False
+        if self._storage is not None:
+            try:
+                was_already_liked = await self._provider.is_liked(ctx.track)
+            except Exception:
+                was_already_liked = False
+
         try:
             await self._provider.like(ctx.track)
         except Exception as e:
@@ -48,9 +63,10 @@ class Pipeline:
         if self._storage is not None:
             try:
                 user_id = await self._provider.user_id()
-                ctx.like_count = await self._storage.increment(user_id, ctx.track)
+                ctx.like_count = await self._storage.increment(
+                    user_id, ctx.track, was_already_liked
+                )
             except Exception:
-                # Soft fail: counter unavailable, like still succeeded.
                 ctx.like_count = None
 
         title = "Liked" if ctx.like_count is None else f"Liked × {ctx.like_count}"

--- a/like_spotify/core/storage.py
+++ b/like_spotify/core/storage.py
@@ -18,8 +18,20 @@ class Storage(ABC):
     """
 
     @abstractmethod
-    async def increment(self, user_id: str, track: CurrentTrack) -> int:
-        """Atomically bump the like counter for (user, track). Returns new count."""
+    async def increment(
+        self,
+        user_id: str,
+        track: CurrentTrack,
+        was_already_liked: bool = False,
+    ) -> int:
+        """Atomically bump the like counter for (user, track). Returns new count.
+
+        `was_already_liked` is the provider's "this was already in your liked
+        collection before we ever saw it" signal (#24 backfill). On the very
+        first encounter, an impl SHOULD treat that as count=2 instead of 1;
+        on subsequent encounters the flag MUST be ignored. The flag is set
+        at most once per (user, track) — backfill is idempotent.
+        """
 
     @abstractmethod
     async def get_count(self, user_id: str, track: CurrentTrack) -> int:

--- a/like_spotify/core/storage.py
+++ b/like_spotify/core/storage.py
@@ -27,10 +27,12 @@ class Storage(ABC):
         """Atomically bump the like counter for (user, track). Returns new count.
 
         `was_already_liked` is the provider's "this was already in your liked
-        collection before we ever saw it" signal (#24 backfill). On the very
-        first encounter, an impl SHOULD treat that as count=2 instead of 1;
-        on subsequent encounters the flag MUST be ignored. The flag is set
-        at most once per (user, track) — backfill is idempotent.
+        collection before we ever saw it" signal (#24 backfill). Callers MAY
+        pass `True` on every press (the pipeline re-probes each time);
+        impls MUST only honour it on the very first INSERT — treat that
+        first encounter as count=2 instead of 1 — and ignore the flag on
+        every subsequent UPDATE. Backfill is therefore idempotent regardless
+        of how many times True is passed afterwards.
         """
 
     @abstractmethod

--- a/like_spotify/extensions/spotify/__init__.py
+++ b/like_spotify/extensions/spotify/__init__.py
@@ -55,6 +55,9 @@ class SpotifyMusicProvider(MusicProvider):
     async def like(self, track: CurrentTrack) -> None:
         await asyncio.to_thread(self._like_sync, track.provider_track_id)
 
+    async def is_liked(self, track: CurrentTrack) -> bool:
+        return await asyncio.to_thread(self._is_liked_sync, track.provider_track_id)
+
     async def user_id(self) -> str:
         if self._user_id_cache:
             return self._user_id_cache
@@ -198,6 +201,18 @@ class SpotifyMusicProvider(MusicProvider):
             timeout=5,
         )
         _raise_for_status(r)
+
+    def _is_liked_sync(self, track_id: str) -> bool:
+        token = self._access_token()
+        r = requests.get(
+            f"{API_BASE}/me/tracks/contains",
+            headers={"Authorization": f"Bearer {token}"},
+            params={"ids": track_id},
+            timeout=5,
+        )
+        _raise_for_status(r)
+        body = r.json()
+        return bool(body) and bool(body[0])
 
     def _fetch_user_id_sync(self) -> str:
         token = self._access_token()

--- a/like_spotify/extensions/supabase_storage/__init__.py
+++ b/like_spotify/extensions/supabase_storage/__init__.py
@@ -4,9 +4,14 @@ Wraps the `increment_track_like` RPC (returns the new total) and a
 SELECT on `track_likes` for `get_count`. Sync `requests` wrapped in
 `asyncio.to_thread`, mirroring the SpotifyMusicProvider style.
 
-Schema (existing, no migration this slice):
-    table track_likes(user_id text, track_id text, count int, PRIMARY KEY(user_id, track_id))
-    function increment_track_like(p_user_id text, p_track_id text) returns int
+Canonical schema lives in `docs/supabase-setup.sql`. Summary:
+    table  track_likes(
+        user_id text, track_id text, count int, backfilled bool,
+        primary key(user_id, track_id))
+    func   increment_track_like(
+        p_user_id text, p_track_id text, p_was_already_liked bool default false)
+        returns int   -- inserts (count=2, backfilled=true) if flag is true on
+                      -- first encounter; plain +1 on every subsequent press.
 """
 
 from __future__ import annotations

--- a/like_spotify/extensions/supabase_storage/__init__.py
+++ b/like_spotify/extensions/supabase_storage/__init__.py
@@ -30,8 +30,18 @@ class SupabaseStorage(Storage):
         self._key = anon_key
         self._timeout = timeout
 
-    async def increment(self, user_id: str, track: CurrentTrack) -> int:
-        return await asyncio.to_thread(self._increment_sync, user_id, track.provider_track_id)
+    async def increment(
+        self,
+        user_id: str,
+        track: CurrentTrack,
+        was_already_liked: bool = False,
+    ) -> int:
+        return await asyncio.to_thread(
+            self._increment_sync,
+            user_id,
+            track.provider_track_id,
+            was_already_liked,
+        )
 
     async def get_count(self, user_id: str, track: CurrentTrack) -> int:
         return await asyncio.to_thread(self._get_count_sync, user_id, track.provider_track_id)
@@ -45,11 +55,20 @@ class SupabaseStorage(Storage):
             "Authorization": f"Bearer {self._key}",
         }
 
-    def _increment_sync(self, user_id: str, track_id: str) -> int:
+    def _increment_sync(
+        self,
+        user_id: str,
+        track_id: str,
+        was_already_liked: bool,
+    ) -> int:
         r = requests.post(
             f"{self._url}/rest/v1/rpc/increment_track_like",
             headers=self._headers(),
-            json={"p_user_id": user_id, "p_track_id": track_id},
+            json={
+                "p_user_id": user_id,
+                "p_track_id": track_id,
+                "p_was_already_liked": was_already_liked,
+            },
             timeout=self._timeout,
         )
         if r.status_code >= 500:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,9 @@
-"""Smoke tests for the pipeline (#21) + Storage wiring (#22).
+"""Smoke tests for the pipeline.
+
+Slices:
+    #21 — tracer-bullet currently_playing → like → feedback.
+    #22 — Storage wiring + count in feedback title.
+    #24 — backfill probe (is_liked → was_already_liked → Storage.increment).
 
 Network / keyboard / tray are not exercised — we mock MusicProvider +
 Storage and verify the core composition flows the way the host depends on.
@@ -19,12 +24,17 @@ class FakeProvider(MusicProvider):
         self,
         track: CurrentTrack | None,
         like_raises: Exception | None = None,
+        is_liked_value: bool = False,
+        is_liked_raises: Exception | None = None,
         user: str = "user-id",
     ):
         self._track = track
         self._like_raises = like_raises
+        self._is_liked_value = is_liked_value
+        self._is_liked_raises = is_liked_raises
         self._user = user
         self.like_calls: list[CurrentTrack] = []
+        self.is_liked_calls: list[CurrentTrack] = []
         self.user_id_calls = 0
 
     async def get_currently_playing(self) -> CurrentTrack | None:
@@ -35,28 +45,48 @@ class FakeProvider(MusicProvider):
             raise self._like_raises
         self.like_calls.append(track)
 
+    async def is_liked(self, track: CurrentTrack) -> bool:
+        self.is_liked_calls.append(track)
+        if self._is_liked_raises is not None:
+            raise self._is_liked_raises
+        return self._is_liked_value
+
     async def user_id(self) -> str:
         self.user_id_calls += 1
         return self._user
 
 
 class FakeStorage(Storage):
-    def __init__(self, counts: dict[tuple[str, str], int] | None = None,
-                 raises: Exception | None = None):
-        self._counts = counts or {}
+    def __init__(self, raises: Exception | None = None):
         self._raises = raises
-        self.increment_calls: list[tuple[str, str]] = []
+        # Records: (user_id, track_id, was_already_liked, count_after)
+        self.increment_calls: list[tuple[str, str, bool]] = []
+        self._rows: dict[tuple[str, str], dict] = {}
 
-    async def increment(self, user_id: str, track: CurrentTrack) -> int:
+    async def increment(
+        self,
+        user_id: str,
+        track: CurrentTrack,
+        was_already_liked: bool = False,
+    ) -> int:
         if self._raises is not None:
             raise self._raises
         key = (user_id, track.provider_track_id)
-        self.increment_calls.append(key)
-        self._counts[key] = self._counts.get(key, 0) + 1
-        return self._counts[key]
+        self.increment_calls.append((user_id, track.provider_track_id, was_already_liked))
+        if key not in self._rows:
+            self._rows[key] = {
+                "count": 2 if was_already_liked else 1,
+                "backfilled": was_already_liked,
+            }
+        else:
+            self._rows[key]["count"] += 1
+        return self._rows[key]["count"]
 
     async def get_count(self, user_id: str, track: CurrentTrack) -> int:
-        return self._counts.get((user_id, track.provider_track_id), 0)
+        return self._rows.get((user_id, track.provider_track_id), {}).get("count", 0)
+
+    def row(self, user_id: str, track_id: str) -> dict:
+        return self._rows[(user_id, track_id)]
 
 
 class Feedback:
@@ -126,7 +156,7 @@ async def test_storage_increment_count_surfaces_in_title() -> None:
     await Pipeline(provider=provider, feedback=fb, storage=storage).run_once()
     await Pipeline(provider=provider, feedback=fb, storage=storage).run_once()
 
-    assert storage.increment_calls == [("user-id", "abc123")] * 3
+    assert [c[:2] for c in storage.increment_calls] == [("user-id", "abc123")] * 3
     assert [c[1] for c in fb.calls] == ["Liked × 1", "Liked × 2", "Liked × 3"]
 
 
@@ -141,7 +171,7 @@ async def test_storage_failure_does_not_fail_like() -> None:
     assert provider.like_calls == [_track()]
     success, title, _ = fb.calls[0]
     assert success is True
-    assert title == "Liked"  # no count suffix on soft fail
+    assert title == "Liked"
 
 
 @pytest.mark.asyncio
@@ -153,3 +183,103 @@ async def test_storage_not_called_when_like_fails() -> None:
     await Pipeline(provider=provider, feedback=fb, storage=storage).run_once()
 
     assert storage.increment_calls == []
+
+
+# ── #24: backfill ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_is_liked_probe_when_storage_absent() -> None:
+    """Skipping the probe saves a Spotify API call on every press."""
+    provider = FakeProvider(track=_track(), is_liked_value=True)
+    fb = Feedback()
+
+    await Pipeline(provider=provider, feedback=fb).run_once()
+
+    assert provider.is_liked_calls == []
+    assert provider.like_calls == [_track()]
+
+
+@pytest.mark.asyncio
+async def test_first_encounter_already_liked_passes_flag_true() -> None:
+    provider = FakeProvider(track=_track(), is_liked_value=True)
+    storage = FakeStorage()
+    fb = Feedback()
+
+    await Pipeline(provider=provider, feedback=fb, storage=storage).run_once()
+
+    assert provider.is_liked_calls == [_track()]
+    assert storage.increment_calls == [("user-id", "abc123", True)]
+    # FakeStorage mirrors the RPC: was_already_liked=True on INSERT → count=2.
+    assert fb.calls[0][1] == "Liked × 2"
+
+
+@pytest.mark.asyncio
+async def test_subsequent_like_ignores_was_already_liked_flag() -> None:
+    """The flag matters only on INSERT — backfill is idempotent."""
+    track = _track()
+    storage = FakeStorage()
+
+    p1 = FakeProvider(track=track, is_liked_value=True)
+    await Pipeline(provider=p1, feedback=Feedback(), storage=storage).run_once()
+
+    # Second press: even if is_liked says True again, count goes 2 → 3,
+    # backfilled flag in row stays as it was.
+    p2 = FakeProvider(track=track, is_liked_value=True)
+    fb2 = Feedback()
+    await Pipeline(provider=p2, feedback=fb2, storage=storage).run_once()
+
+    row = storage.row("user-id", "abc123")
+    assert row == {"count": 3, "backfilled": True}
+    assert fb2.calls[0][1] == "Liked × 3"
+
+
+@pytest.mark.asyncio
+async def test_first_encounter_not_already_liked_passes_flag_false() -> None:
+    provider = FakeProvider(track=_track(), is_liked_value=False)
+    storage = FakeStorage()
+    fb = Feedback()
+
+    await Pipeline(provider=provider, feedback=fb, storage=storage).run_once()
+
+    assert storage.increment_calls == [("user-id", "abc123", False)]
+    assert storage.row("user-id", "abc123") == {"count": 1, "backfilled": False}
+    assert fb.calls[0][1] == "Liked × 1"
+
+
+@pytest.mark.asyncio
+async def test_is_liked_failure_falls_back_to_false() -> None:
+    """Soft fail on the probe — better to miss a backfill than double-count."""
+    provider = FakeProvider(
+        track=_track(), is_liked_raises=RuntimeError("contains 500")
+    )
+    storage = FakeStorage()
+    fb = Feedback()
+
+    await Pipeline(provider=provider, feedback=fb, storage=storage).run_once()
+
+    assert provider.like_calls == [_track()]
+    assert storage.increment_calls == [("user-id", "abc123", False)]
+    assert fb.calls[0][0] is True
+
+
+@pytest.mark.asyncio
+async def test_is_liked_probed_before_like() -> None:
+    """Probe before write — likeing first would always return True."""
+    call_order: list[str] = []
+
+    class OrderedProvider(FakeProvider):
+        async def is_liked(self, track: CurrentTrack) -> bool:
+            call_order.append("is_liked")
+            return await super().is_liked(track)
+
+        async def like(self, track: CurrentTrack) -> None:
+            call_order.append("like")
+            await super().like(track)
+
+    provider = OrderedProvider(track=_track(), is_liked_value=False)
+    await Pipeline(
+        provider=provider, feedback=Feedback(), storage=FakeStorage()
+    ).run_once()
+
+    assert call_order == ["is_liked", "like"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -59,7 +59,7 @@ class FakeProvider(MusicProvider):
 class FakeStorage(Storage):
     def __init__(self, raises: Exception | None = None):
         self._raises = raises
-        # Records: (user_id, track_id, was_already_liked, count_after)
+        # Records: (user_id, track_id, was_already_liked)
         self.increment_calls: list[tuple[str, str, bool]] = []
         self._rows: dict[tuple[str, str], dict] = {}
 
@@ -265,7 +265,7 @@ async def test_is_liked_failure_falls_back_to_false() -> None:
 
 @pytest.mark.asyncio
 async def test_is_liked_probed_before_like() -> None:
-    """Probe before write — likeing first would always return True."""
+    """Probe before write — liking first would always return True."""
     call_order: list[str] = []
 
     class OrderedProvider(FakeProvider):

--- a/tests/test_spotify_provider.py
+++ b/tests/test_spotify_provider.py
@@ -1,0 +1,88 @@
+"""Contract tests for SpotifyMusicProvider — slice-scoped to #24.
+
+We don't re-test the OAuth flow here; just the read-side calls the
+pipeline added on this slice: `is_liked` against `/me/tracks/contains`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from like_spotify.core.types import CurrentTrack
+from like_spotify.extensions.spotify import SpotifyMusicProvider
+
+
+@dataclass
+class FakeResponse:
+    status_code: int
+    text: str = ""
+    json_body: Any = None
+    headers: dict[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.headers is None:
+            self.headers = {}
+
+    def json(self) -> Any:
+        return self.json_body
+
+
+def _provider(tmp_path) -> SpotifyMusicProvider:
+    """Build a provider with a primed access token to skip auth refresh."""
+    import time
+
+    token_path = tmp_path / "token.json"
+    p = SpotifyMusicProvider(client_id="cid", token_path=token_path)
+    # Inject a non-expired access token so _access_token() short-circuits.
+    p._tokens = {
+        "access_token": "test-token",
+        "refresh_token": "rt",
+        "expires_at": time.time() + 3600,
+    }
+    return p
+
+
+def _track(track_id: str = "trk1") -> CurrentTrack:
+    return CurrentTrack(
+        provider="spotify", provider_track_id=track_id, title="t", artists=("a",)
+    )
+
+
+@pytest.mark.asyncio
+async def test_is_liked_true(monkeypatch, tmp_path) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        captured["url"] = url
+        captured["params"] = params
+        return FakeResponse(status_code=200, json_body=[True])
+
+    monkeypatch.setattr("like_spotify.extensions.spotify.requests.get", fake_get)
+
+    p = _provider(tmp_path)
+    assert await p.is_liked(_track("trk-42")) is True
+    assert captured["url"].endswith("/me/tracks/contains")
+    assert captured["params"] == {"ids": "trk-42"}
+
+
+@pytest.mark.asyncio
+async def test_is_liked_false(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        "like_spotify.extensions.spotify.requests.get",
+        lambda *a, **kw: FakeResponse(status_code=200, json_body=[False]),
+    )
+    p = _provider(tmp_path)
+    assert await p.is_liked(_track()) is False
+
+
+@pytest.mark.asyncio
+async def test_is_liked_empty_body_treated_as_false(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(
+        "like_spotify.extensions.spotify.requests.get",
+        lambda *a, **kw: FakeResponse(status_code=200, json_body=[]),
+    )
+    p = _provider(tmp_path)
+    assert await p.is_liked(_track()) is False

--- a/tests/test_supabase_storage.py
+++ b/tests/test_supabase_storage.py
@@ -58,10 +58,33 @@ async def test_increment_posts_to_rpc_and_returns_count(monkeypatch) -> None:
 
     assert count == 7
     assert captured["url"] == "https://x.supabase.co/rest/v1/rpc/increment_track_like"
-    assert captured["json"] == {"p_user_id": "user-1", "p_track_id": "trk-42"}
+    assert captured["json"] == {
+        "p_user_id": "user-1",
+        "p_track_id": "trk-42",
+        "p_was_already_liked": False,
+    }
     h = captured["headers"]
     assert h["apikey"] == "anonkey"
     assert h["Authorization"] == "Bearer anonkey"
+
+
+@pytest.mark.asyncio
+async def test_increment_passes_was_already_liked_flag(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return FakeResponse(status_code=200, text="2")
+
+    monkeypatch.setattr(
+        "like_spotify.extensions.supabase_storage.requests.post", fake_post
+    )
+
+    storage = SupabaseStorage(url="https://x.supabase.co", anon_key="k")
+    count = await storage.increment("user-1", _track(), was_already_liked=True)
+
+    assert count == 2
+    assert captured["json"]["p_was_already_liked"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Slice 3 of the Phase 1 OSS refactor (#19). Builds straight on the `Storage` extension point from #22.

Before writing the like, peek at the provider's "is this already in your liked collection" signal; on the very first encounter of a pre-existing like, the counter starts at **2** instead of 1. The flag is idempotent — it only affects the INSERT path, subsequent likes are plain `+1`.

### What moved

- **`docs/supabase-setup.sql`** — canonical schema, fully idempotent (`CREATE TABLE IF NOT EXISTS`, `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, `CREATE OR REPLACE FUNCTION`). Safe on fresh installs and on existing projects upgrading for this slice. Existing `track_likes` rows default `backfilled=false` — no retroactive backfill, per AC.
- **`MusicProvider`** — new `is_liked(track) -> bool`. Spotify impl wraps `GET /me/tracks/contains`.
- **`Storage.increment`** — new `was_already_liked: bool = False` parameter. `SupabaseStorage` forwards it as `p_was_already_liked` in the RPC body.
- **`Pipeline`** — probes `is_liked` **only when Storage is wired** (saves one Spotify call per press when no counter is configured). Probe runs *before* `like()` so we see the original state. Soft fail to `False` — better to miss a backfill than risk double-counting.

### RPC contract (matches AC)

| Scenario | RPC behaviour |
|---|---|
| Row absent, `p_was_already_liked=true` | INSERT `count=2, backfilled=true` |
| Row absent, `p_was_already_liked=false` | INSERT `count=1, backfilled=false` |
| Row present | UPDATE `count = count + 1`; `backfilled` untouched |

## Acceptance criteria (#24)

- [x] Track in Spotify Liked Songs but not yet in `track_likes` → first like → row inserted with `count=2, backfilled=true` (`test_first_encounter_already_liked_passes_flag_true`).
- [x] Same track liked again → `count=3`, `backfilled` unchanged (`test_subsequent_like_ignores_was_already_liked_flag`).
- [x] Track NOT in Spotify Liked → first like → row inserted with `count=1, backfilled=false` (`test_first_encounter_not_already_liked_passes_flag_false`).
- [x] Existing rows untouched after migration (column defaults to `false`; RPC uses `ON CONFLICT DO UPDATE` that does not touch `backfilled`).
- [x] Migration idempotent (`IF NOT EXISTS` on table + column, `CREATE OR REPLACE` on function).
- [x] One Spotify API call added pre-like (`/me/tracks/contains`), gated on Storage presence — `test_no_is_liked_probe_when_storage_absent` confirms the call is skipped otherwise.

## Test plan

- [x] `python -m pytest tests/` — 22/22 pass.
- [x] `python -c "from like_spotify.hosts.tray import main"` — clean import.
- [ ] Run `docs/supabase-setup.sql` against the live Supabase project, then exercise the tray host with a known-already-liked track — pending (not wired locally in this session).

## Out of scope

- Action interfaces (Pre/Post + ArchiveRemoveAction) → #23.
- GoogleSheetsStorage second impl → #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)