### PR TITLE
feat(desktop): GoogleSheetsStorage + shared Storage contract suite (#25 core)

### DIFF
--- a/like_spotify/extensions/google_sheets_storage/__init__.py
+++ b/like_spotify/extensions/google_sheets_storage/__init__.py
@@ -1,0 +1,223 @@
+"""GoogleSheetsStorage — second Storage impl.
+
+Ships as the second reference impl that validates the `Storage`
+abstraction with a backend that's not a SQL-style RPC. Forces the
+interface to honour append + lookup-by-key semantics without leaking
+PostgREST shape.
+
+Sheet schema (per #25): columns `user_id | track_id | count | backfilled | updated_at`,
+with a single header row. The first action invocation reads the sheet
+once to build an in-memory `(user_id, track_id) -> row_index` map;
+subsequent likes do a targeted `values.update` or, on miss, a single
+`values.append`. The backfill flag from #24 is honoured: on the very
+first insert with `was_already_liked=True`, count is seeded at 2 and
+`backfilled` is set to `TRUE`; on every subsequent press, the row is
+updated to `count + 1` and `backfilled` stays as it was.
+
+OAuth is owner-managed: the constructor takes a `token_provider`
+callable that returns a fresh access token at call time. The host
+wires that to whatever refresh strategy it likes (the `--setup`
+integration lands separately in #28).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+
+import requests
+
+from like_spotify.core.errors import TransientError
+from like_spotify.core.storage import Storage
+from like_spotify.core.types import CurrentTrack
+
+DOMAIN = "google_sheets"
+
+API_BASE = "https://sheets.googleapis.com/v4/spreadsheets"
+DEFAULT_SHEET = "Likes"
+HEADER_ROW = ["user_id", "track_id", "count", "backfilled", "updated_at"]
+
+
+TokenProvider = Callable[[], str]
+
+
+class GoogleSheetsStorage(Storage):
+    def __init__(
+        self,
+        spreadsheet_id: str,
+        token_provider: TokenProvider,
+        sheet_name: str = DEFAULT_SHEET,
+        timeout: float = 5.0,
+    ) -> None:
+        if not spreadsheet_id:
+            raise ValueError("spreadsheet_id is required")
+        if token_provider is None:
+            raise ValueError("token_provider is required")
+        self._sid = spreadsheet_id
+        self._token = token_provider
+        self._sheet = sheet_name
+        self._timeout = timeout
+        # Filled on first access. Row index is 1-based and INCLUDES the
+        # header row, so the first data row is index 2.
+        self._row_index: dict[tuple[str, str], int] | None = None
+        self._count_cache: dict[tuple[str, str], int] = {}
+
+    async def increment(
+        self,
+        user_id: str,
+        track: CurrentTrack,
+        was_already_liked: bool = False,
+    ) -> int:
+        return await asyncio.to_thread(
+            self._increment_sync, user_id, track.provider_track_id, was_already_liked
+        )
+
+    async def get_count(self, user_id: str, track: CurrentTrack) -> int:
+        return await asyncio.to_thread(
+            self._get_count_sync, user_id, track.provider_track_id
+        )
+
+    # ── Internals ────────────────────────────────────────────────────────
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._token()}",
+            "Content-Type": "application/json",
+        }
+
+    def _ensure_loaded(self) -> None:
+        if self._row_index is not None:
+            return
+        r = requests.get(
+            f"{API_BASE}/{self._sid}/values/{self._sheet}",
+            headers=self._headers(),
+            timeout=self._timeout,
+        )
+        if r.status_code >= 500:
+            raise TransientError(f"sheets get 5xx: {r.status_code}")
+        if r.status_code >= 400:
+            raise RuntimeError(f"sheets get {r.status_code}: {r.text}")
+        rows = r.json().get("values", []) or []
+        index: dict[tuple[str, str], int] = {}
+        counts: dict[tuple[str, str], int] = {}
+        # Row 1 is the header; data starts at row 2.
+        for offset, row in enumerate(rows[1:], start=2):
+            if len(row) < 3:
+                continue
+            key = (row[0], row[1])
+            index[key] = offset
+            try:
+                counts[key] = int(row[2])
+            except (TypeError, ValueError):
+                counts[key] = 0
+        self._row_index = index
+        self._count_cache = counts
+
+    def _increment_sync(
+        self, user_id: str, track_id: str, was_already_liked: bool
+    ) -> int:
+        self._ensure_loaded()
+        assert self._row_index is not None  # for type checker
+        key = (user_id, track_id)
+        now = _now_iso()
+
+        if key in self._row_index:
+            new_count = self._count_cache.get(key, 0) + 1
+            # Targeted UPDATE; leave backfilled column alone (col D),
+            # rewrite count (col C) and updated_at (col E).
+            self._values_update(
+                f"{self._sheet}!C{self._row_index[key]}:C{self._row_index[key]}",
+                [[new_count]],
+            )
+            self._values_update(
+                f"{self._sheet}!E{self._row_index[key]}:E{self._row_index[key]}",
+                [[now]],
+            )
+            self._count_cache[key] = new_count
+            return new_count
+
+        # APPEND new row. Backfill flag honoured on this first encounter.
+        new_count = 2 if was_already_liked else 1
+        row = [user_id, track_id, new_count, "TRUE" if was_already_liked else "FALSE", now]
+        appended_index = self._values_append(row)
+        self._row_index[key] = appended_index
+        self._count_cache[key] = new_count
+        return new_count
+
+    def _get_count_sync(self, user_id: str, track_id: str) -> int:
+        self._ensure_loaded()
+        return self._count_cache.get((user_id, track_id), 0)
+
+    def _values_update(self, range_a1: str, values: list[list]) -> None:
+        r = requests.put(
+            f"{API_BASE}/{self._sid}/values/{range_a1}",
+            headers=self._headers(),
+            params={"valueInputOption": "RAW"},
+            json={"values": values},
+            timeout=self._timeout,
+        )
+        if r.status_code >= 500:
+            raise TransientError(f"sheets update 5xx: {r.status_code}")
+        if r.status_code >= 400:
+            raise RuntimeError(f"sheets update {r.status_code}: {r.text}")
+
+    def _values_append(self, row: list) -> int:
+        """Append one row; return the 1-based row index it landed on."""
+        r = requests.post(
+            f"{API_BASE}/{self._sid}/values/{self._sheet}:append",
+            headers=self._headers(),
+            params={
+                "valueInputOption": "RAW",
+                "insertDataOption": "INSERT_ROWS",
+            },
+            json={"values": [row]},
+            timeout=self._timeout,
+        )
+        if r.status_code >= 500:
+            raise TransientError(f"sheets append 5xx: {r.status_code}")
+        if r.status_code >= 400:
+            raise RuntimeError(f"sheets append {r.status_code}: {r.text}")
+        body = r.json()
+        # The "updates.updatedRange" comes back as 'Likes!A7:E7' — parse the row.
+        updated_range = (body.get("updates") or {}).get("updatedRange", "")
+        return _row_from_a1_range(updated_range)
+
+
+# ── Module-level helpers ─────────────────────────────────────────────────
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _row_from_a1_range(a1: str) -> int:
+    """Extract the row number from an A1 range like 'Likes!A7:E7' → 7.
+
+    Falls back to a large number on parse failure so the index stays
+    consistent enough for in-memory use (a refresh re-syncs anyway).
+    """
+    # Find the last numeric run in the string.
+    digits = ""
+    for ch in reversed(a1):
+        if ch.isdigit():
+            digits = ch + digits
+        elif digits:
+            break
+    try:
+        return int(digits)
+    except ValueError:
+        return 0
+
+
+def STORAGE(
+    spreadsheet_id: str,
+    token_provider: TokenProvider,
+    sheet_name: str = DEFAULT_SHEET,
+) -> GoogleSheetsStorage:
+    """Factory called by the host. Signature widens in #28 (manifest deps)."""
+    return GoogleSheetsStorage(
+        spreadsheet_id=spreadsheet_id,
+        token_provider=token_provider,
+        sheet_name=sheet_name,
+    )

--- a/like_spotify/extensions/google_sheets_storage/manifest.json
+++ b/like_spotify/extensions/google_sheets_storage/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "google_sheets",
+  "extension_point": "storage",
+  "name": "Google Sheets",
+  "description": "Like counter persisted to a Google Sheet. Second Storage impl validating the abstraction.",
+  "codeowners": ["@Osasuwu"],
+  "requirements": ["requests>=2.31"],
+  "documentation": "https://github.com/Osasuwu/like_spotify_mobile_app/blob/main/like_spotify/extensions/google_sheets_storage/README.md",
+  "stage": "alpha"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ exclude = ["tests*"]
 
 [tool.setuptools.package-data]
 "like_spotify.extensions.archive_remove" = ["manifest.json"]
+"like_spotify.extensions.google_sheets_storage" = ["manifest.json"]
 "like_spotify.extensions.spotify" = ["manifest.json"]
 "like_spotify.extensions.supabase_storage" = ["manifest.json"]
 "like_spotify.extensions.tray_hotkey_trigger" = ["manifest.json"]

--- a/tests/test_google_sheets_storage.py
+++ b/tests/test_google_sheets_storage.py
@@ -1,0 +1,226 @@
+"""HTTP-level tests for GoogleSheetsStorage (#25).
+
+`requests` is monkey-patched onto an in-memory simulator that mirrors
+the real Sheets `values.get / values.update / values.append` semantics
+just enough to drive the storage contract. The simulator is owned by
+this module — the contract-level invariants live in
+`tests/test_storage_contract.py` and run against both Supabase and
+Sheets impls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from like_spotify.core.errors import TransientError
+from like_spotify.core.types import CurrentTrack
+from like_spotify.extensions.google_sheets_storage import GoogleSheetsStorage
+
+
+@dataclass
+class FakeResponse:
+    status_code: int
+    text: str = ""
+    json_body: Any = None
+
+    def json(self) -> Any:
+        return self.json_body
+
+
+class SheetsSim:
+    """Minimal stand-in for Google Sheets' values endpoints."""
+
+    def __init__(self, sheet: str = "Likes") -> None:
+        # First row is the header; data starts at row index 2.
+        self.rows: list[list] = [["user_id", "track_id", "count", "backfilled", "updated_at"]]
+        self.sheet = sheet
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def handle_get(self, url: str, **kw) -> FakeResponse:
+        self.calls.append(("GET", url, kw))
+        return FakeResponse(status_code=200, json_body={"values": list(self.rows)})
+
+    def handle_post(self, url: str, **kw) -> FakeResponse:
+        self.calls.append(("POST", url, kw))
+        body = kw.get("json", {})
+        values = body.get("values", [])
+        if not values:
+            return FakeResponse(status_code=400, text="no values")
+        self.rows.extend(values)
+        row_index = len(self.rows)  # 1-based; just appended row
+        return FakeResponse(
+            status_code=200,
+            json_body={
+                "updates": {
+                    "updatedRange": f"{self.sheet}!A{row_index}:E{row_index}",
+                }
+            },
+        )
+
+    def handle_put(self, url: str, **kw) -> FakeResponse:
+        self.calls.append(("PUT", url, kw))
+        # Parse range from url tail: '.../values/Likes!C3:C3'
+        tail = url.rsplit("/values/", 1)[-1]
+        sheet, _, a1 = tail.partition("!")
+        # Column letter + row number; only single-cell updates here.
+        col_letter = a1.split(":")[0].rstrip("0123456789")
+        row_digits = a1.split(":")[0][len(col_letter):]
+        row = int(row_digits)
+        col = ord(col_letter.upper()) - ord("A")
+        new_value = kw["json"]["values"][0][0]
+        while len(self.rows[row - 1]) <= col:
+            self.rows[row - 1].append("")
+        self.rows[row - 1][col] = new_value
+        return FakeResponse(
+            status_code=200,
+            json_body={"updatedRange": f"{sheet}!{a1}", "updatedCells": 1},
+        )
+
+
+@pytest.fixture
+def sim_and_storage(monkeypatch):
+    sim = SheetsSim()
+    monkeypatch.setattr(
+        "like_spotify.extensions.google_sheets_storage.requests.get",
+        sim.handle_get,
+    )
+    monkeypatch.setattr(
+        "like_spotify.extensions.google_sheets_storage.requests.post",
+        sim.handle_post,
+    )
+    monkeypatch.setattr(
+        "like_spotify.extensions.google_sheets_storage.requests.put",
+        sim.handle_put,
+    )
+    storage = GoogleSheetsStorage(
+        spreadsheet_id="sheet-1",
+        token_provider=lambda: "tok",
+        sheet_name="Likes",
+    )
+    return sim, storage
+
+
+def _track(track_id: str = "trk1") -> CurrentTrack:
+    return CurrentTrack(
+        provider="spotify", provider_track_id=track_id, title="t", artists=("a",)
+    )
+
+
+def test_constructor_rejects_missing_args() -> None:
+    with pytest.raises(ValueError):
+        GoogleSheetsStorage(spreadsheet_id="", token_provider=lambda: "t")
+    with pytest.raises(ValueError):
+        GoogleSheetsStorage(spreadsheet_id="s", token_provider=None)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_first_encounter_appends_row(sim_and_storage) -> None:
+    sim, storage = sim_and_storage
+
+    count = await storage.increment("user-1", _track("trk-a"))
+
+    assert count == 1
+    methods = [c[0] for c in sim.calls]
+    assert "GET" in methods  # one-time index load
+    assert "POST" in methods  # append
+    # Row landed: user_id, track_id, count, backfilled, updated_at
+    last = sim.rows[-1]
+    assert last[0] == "user-1"
+    assert last[1] == "trk-a"
+    assert last[2] == 1
+    assert last[3] == "FALSE"
+
+
+@pytest.mark.asyncio
+async def test_first_encounter_was_already_liked_seeds_count_2(
+    sim_and_storage,
+) -> None:
+    sim, storage = sim_and_storage
+
+    count = await storage.increment(
+        "user-1", _track("trk-a"), was_already_liked=True
+    )
+
+    assert count == 2
+    last = sim.rows[-1]
+    assert last[2] == 2
+    assert last[3] == "TRUE"
+
+
+@pytest.mark.asyncio
+async def test_subsequent_increments_update_existing_row(sim_and_storage) -> None:
+    sim, storage = sim_and_storage
+
+    await storage.increment("user-1", _track("trk-a"))
+    await storage.increment("user-1", _track("trk-a"))
+    third = await storage.increment("user-1", _track("trk-a"))
+
+    assert third == 3
+    # Only ONE data row total — subsequent presses are UPDATEs, not APPENDs.
+    data_rows = [r for r in sim.rows[1:] if r[0] == "user-1" and r[1] == "trk-a"]
+    assert len(data_rows) == 1
+    assert data_rows[0][2] == 3
+
+    post_calls = [c for c in sim.calls if c[0] == "POST"]
+    put_calls = [c for c in sim.calls if c[0] == "PUT"]
+    assert len(post_calls) == 1  # only the first APPEND
+    # Two PUTs per UPDATE press (count + updated_at), 2 presses past first → 4.
+    assert len(put_calls) == 4
+
+
+@pytest.mark.asyncio
+async def test_backfill_flag_ignored_on_update(sim_and_storage) -> None:
+    """The `was_already_liked` flag must only affect the INSERT row.
+    Repeated True passes do not touch the `backfilled` column."""
+    sim, storage = sim_and_storage
+
+    await storage.increment("user-1", _track("trk-a"), was_already_liked=True)
+    await storage.increment("user-1", _track("trk-a"), was_already_liked=True)
+    final = await storage.increment("user-1", _track("trk-a"), was_already_liked=True)
+
+    assert final == 4  # 2 (insert) + 1 + 1
+    row = next(r for r in sim.rows[1:] if r[0] == "user-1" and r[1] == "trk-a")
+    assert row[3] == "TRUE"
+
+
+@pytest.mark.asyncio
+async def test_get_count_returns_cached_value(sim_and_storage) -> None:
+    sim, storage = sim_and_storage
+
+    await storage.increment("user-1", _track("trk-a"))
+    await storage.increment("user-1", _track("trk-a"))
+
+    assert await storage.get_count("user-1", _track("trk-a")) == 2
+    assert await storage.get_count("user-1", _track("missing")) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_request_5xx_raises_transient(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "like_spotify.extensions.google_sheets_storage.requests.get",
+        lambda *a, **kw: FakeResponse(status_code=503, text="upstream"),
+    )
+    storage = GoogleSheetsStorage(
+        spreadsheet_id="s", token_provider=lambda: "t"
+    )
+    with pytest.raises(TransientError):
+        await storage.increment("u", _track())
+
+
+@pytest.mark.asyncio
+async def test_token_provider_invoked_per_call(sim_and_storage) -> None:
+    sim, storage = sim_and_storage
+    calls = []
+
+    def provider() -> str:
+        calls.append(1)
+        return f"tok-{len(calls)}"
+
+    storage._token = provider
+
+    await storage.increment("user-1", _track())
+    # GET (load) + POST (append) → 2 token calls minimum.
+    assert len(calls) >= 2

--- a/tests/test_storage_contract.py
+++ b/tests/test_storage_contract.py
@@ -1,0 +1,217 @@
+"""Storage contract suite — parametrized across every shipped impl.
+
+Each impl is wired to an in-memory simulator over `requests`; the tests
+themselves only see the `Storage` ABC and assert the invariants that
+the abstraction promises:
+
+    - increment N times → count goes 1, 2, 3, … N
+    - first encounter with `was_already_liked=True` → count 2
+    - subsequent presses with True still in effect → +1 each, NOT +2
+      (backfill is idempotent — flag only matters on INSERT)
+    - increment with False then True → count goes 1, then 2 (the flag is
+      ignored after first encounter)
+    - get_count for a never-touched key → 0
+    - get_count for an existing key → current count
+
+A regression on either impl that breaks the contract surfaces here
+*before* the impl-specific HTTP-shape tests catch it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from like_spotify.core.storage import Storage
+from like_spotify.core.types import CurrentTrack
+from like_spotify.extensions.google_sheets_storage import GoogleSheetsStorage
+from like_spotify.extensions.supabase_storage import SupabaseStorage
+
+
+# ── Fake backends ────────────────────────────────────────────────────────
+
+
+@dataclass
+class FakeResponse:
+    status_code: int
+    text: str = ""
+    json_body: Any = None
+
+    def json(self) -> Any:
+        return self.json_body
+
+
+class SupabaseSim:
+    """In-memory mirror of the increment_track_like RPC + track_likes table."""
+
+    def __init__(self) -> None:
+        self.rows: dict[tuple[str, str], dict] = {}
+
+    def handle_post(self, url: str, **kw) -> FakeResponse:
+        body = kw.get("json", {})
+        key = (body["p_user_id"], body["p_track_id"])
+        flag = bool(body.get("p_was_already_liked", False))
+        if key not in self.rows:
+            self.rows[key] = {
+                "count": 2 if flag else 1,
+                "backfilled": flag,
+            }
+        else:
+            self.rows[key]["count"] += 1
+        return FakeResponse(status_code=200, text=str(self.rows[key]["count"]))
+
+    def handle_get(self, url: str, **kw) -> FakeResponse:
+        params = kw.get("params") or {}
+        user = (params.get("user_id") or "").removeprefix("eq.")
+        track = (params.get("track_id") or "").removeprefix("eq.")
+        row = self.rows.get((user, track))
+        return FakeResponse(
+            status_code=200,
+            json_body=[{"count": row["count"]}] if row else [],
+        )
+
+
+class SheetsSim:
+    def __init__(self, sheet: str = "Likes") -> None:
+        self.rows: list[list] = [["user_id", "track_id", "count", "backfilled", "updated_at"]]
+        self.sheet = sheet
+
+    def handle_get(self, url: str, **kw) -> FakeResponse:
+        return FakeResponse(status_code=200, json_body={"values": list(self.rows)})
+
+    def handle_post(self, url: str, **kw) -> FakeResponse:
+        body = kw.get("json", {})
+        for row in body.get("values", []):
+            self.rows.append(list(row))
+        row_index = len(self.rows)
+        return FakeResponse(
+            status_code=200,
+            json_body={"updates": {"updatedRange": f"{self.sheet}!A{row_index}:E{row_index}"}},
+        )
+
+    def handle_put(self, url: str, **kw) -> FakeResponse:
+        tail = url.rsplit("/values/", 1)[-1]
+        _sheet, _, a1 = tail.partition("!")
+        col_letter = a1.split(":")[0].rstrip("0123456789")
+        row_digits = a1.split(":")[0][len(col_letter):]
+        row_idx = int(row_digits)
+        col = ord(col_letter.upper()) - ord("A")
+        new_value = kw["json"]["values"][0][0]
+        while len(self.rows[row_idx - 1]) <= col:
+            self.rows[row_idx - 1].append("")
+        self.rows[row_idx - 1][col] = new_value
+        return FakeResponse(status_code=200, json_body={})
+
+
+# ── Fixtures: each impl wired to its sim ─────────────────────────────────
+
+
+@pytest.fixture
+def supabase_storage(monkeypatch) -> Storage:
+    sim = SupabaseSim()
+    monkeypatch.setattr(
+        "like_spotify.extensions.supabase_storage.requests.post", sim.handle_post
+    )
+    monkeypatch.setattr(
+        "like_spotify.extensions.supabase_storage.requests.get", sim.handle_get
+    )
+    return SupabaseStorage(url="https://x.supabase.co", anon_key="k")
+
+
+@pytest.fixture
+def sheets_storage(monkeypatch) -> Storage:
+    sim = SheetsSim()
+    monkeypatch.setattr(
+        "like_spotify.extensions.google_sheets_storage.requests.get", sim.handle_get
+    )
+    monkeypatch.setattr(
+        "like_spotify.extensions.google_sheets_storage.requests.post", sim.handle_post
+    )
+    monkeypatch.setattr(
+        "like_spotify.extensions.google_sheets_storage.requests.put", sim.handle_put
+    )
+    return GoogleSheetsStorage(
+        spreadsheet_id="s", token_provider=lambda: "tok"
+    )
+
+
+# Parametrize every contract test across both fixtures. Using indirect
+# fixture references keeps the test functions readable.
+@pytest.fixture(params=["supabase_storage", "sheets_storage"])
+def storage(request) -> Storage:
+    return request.getfixturevalue(request.param)
+
+
+def _track(track_id: str = "abc") -> CurrentTrack:
+    return CurrentTrack(
+        provider="spotify", provider_track_id=track_id, title="t", artists=("a",)
+    )
+
+
+# ── Contract invariants ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_increment_returns_running_count(storage: Storage) -> None:
+    c1 = await storage.increment("user-1", _track("trk-a"))
+    c2 = await storage.increment("user-1", _track("trk-a"))
+    c3 = await storage.increment("user-1", _track("trk-a"))
+    assert (c1, c2, c3) == (1, 2, 3)
+
+
+@pytest.mark.asyncio
+async def test_first_encounter_was_already_liked_returns_two(
+    storage: Storage,
+) -> None:
+    count = await storage.increment(
+        "user-1", _track("trk-a"), was_already_liked=True
+    )
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_subsequent_was_already_liked_still_plus_one(
+    storage: Storage,
+) -> None:
+    """Flag is honoured ONCE on INSERT; later presses are plain +1."""
+    a = await storage.increment("user-1", _track("trk-a"), was_already_liked=True)
+    b = await storage.increment("user-1", _track("trk-a"), was_already_liked=True)
+    c = await storage.increment("user-1", _track("trk-a"), was_already_liked=True)
+    assert (a, b, c) == (2, 3, 4)
+
+
+@pytest.mark.asyncio
+async def test_flag_ignored_after_first_encounter_without_it(
+    storage: Storage,
+) -> None:
+    """If first press was False, a later True doesn't retroactively backfill."""
+    a = await storage.increment("user-1", _track("trk-a"), was_already_liked=False)
+    b = await storage.increment("user-1", _track("trk-a"), was_already_liked=True)
+    assert (a, b) == (1, 2)
+
+
+@pytest.mark.asyncio
+async def test_get_count_zero_for_unknown_key(storage: Storage) -> None:
+    assert await storage.get_count("user-1", _track("never")) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_count_reflects_running_total(storage: Storage) -> None:
+    await storage.increment("user-1", _track("trk-a"))
+    await storage.increment("user-1", _track("trk-a"))
+    assert await storage.get_count("user-1", _track("trk-a")) == 2
+
+
+@pytest.mark.asyncio
+async def test_keys_are_independent(storage: Storage) -> None:
+    """Different (user, track) tuples don't bleed into each other."""
+    await storage.increment("user-1", _track("trk-a"))
+    await storage.increment("user-1", _track("trk-a"))
+    await storage.increment("user-2", _track("trk-a"))
+    await storage.increment("user-1", _track("trk-b"))
+
+    assert await storage.get_count("user-1", _track("trk-a")) == 2
+    assert await storage.get_count("user-2", _track("trk-a")) == 1
+    assert await storage.get_count("user-1", _track("trk-b")) == 1


### PR DESCRIPTION
## Summary

Slice 5 of the Phase 1 OSS refactor (#19). Ships the second `Storage` impl that validates the abstraction (per epic AC: "at least 2 reference impls per public interface"), plus a **parametrized contract test suite** that runs against both Supabase and Sheets so regressions on either side surface in CI.

### What's in

- **`extensions/google_sheets_storage/`** — raw `requests` + `asyncio.to_thread`. No `google-api-python-client` dep (mirrors `SupabaseStorage` shape). Sheet schema: `user_id | track_id | count | backfilled | updated_at`. First action invocation reads the sheet once to build an in-memory `(user_id, track_id) → row_index` map; subsequent presses do targeted `values.update` or `values.append` on miss. Backfill flag from #24 is honoured on the INSERT row; on UPDATE the flag is ignored — same idempotency contract as SupabaseStorage.
- **`tests/test_storage_contract.py`** — parametrized invariants over both impls. 7 invariants × 2 fixtures = 14 tests:
  - increment N times → count returns 1..N
  - first-encounter `was_already_liked=True` → count 2
  - subsequent presses with True still in effect → +1 each (idempotent)
  - flag ignored after first-encounter without it (no retroactive backfill)
  - `get_count` returns 0 for unknown keys
  - `get_count` reflects running total
  - distinct `(user, track)` keys are independent
- **`tests/test_google_sheets_storage.py`** — impl-specific HTTP-shape tests (8): append/update routing, backfill seeding, flag idempotency on UPDATE, get_count cache, token provider invoked per call, 5xx → TransientError.

## Acceptance criteria (#25)

- [x] Increment lookup by `(user_id, track_id)` updates existing row (not appends new) — `test_subsequent_increments_update_existing_row`.
- [x] Backfill rule from #24 produces `count=2, backfilled=TRUE` row on first encounter when track was already in Spotify Liked — `test_first_encounter_was_already_liked_seeds_count_2`.
- [x] Both Supabase and Sheets impls pass the same Storage contract test suite — `tests/test_storage_contract.py` (14 tests across both).
- [ ] **User picks `sheets` in `--setup` → walks Google OAuth → like flow writes/updates rows** — **deferred to the `--setup` work in #28** (install bootstrap). See scope note below.

## Scope note — deferred OAuth integration

Full interactive Google OAuth in `--setup` was out of size for one slice (smart-zone discipline). The technical core — the `Storage` impl + contract suite — is in. OAuth wiring lands together with the Spotify-side `--setup` refresh in #28 (install bootstrap + interactive setup), where the OAuth dance for both Spotify and Sheets can be designed in one go (consistent token-store layout, consistent `--reauth` handling, etc.).

The `GoogleSheetsStorage` constructor takes a `token_provider: () -> str` callable so early adopters can wire it from an env-managed token today; the host integration just needs to construct that callable.

I'll open a follow-up issue tagged `phase-1-followup` for the OAuth wiring once #28 starts.

## Test plan

- [x] `python -m pytest tests/` — 58/58 pass.
- [ ] Manual test against a real Google Sheet — pending (no OAuth in this slice, can't run end-to-end yet).

## Out of scope

- OAuth flow integration in `--setup` → tracked separately, folds into #28.
- Tray host wiring (which Storage to instantiate based on config) → also lives in `--setup` UX (#28).
- PromoteToBestOfAction + FollowArtistAction → #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)