### PR TITLE
feat(desktop): install bootstrap + interactive setup wizard (closes #28, finishes #25)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Shell scripts must stay LF — bash chokes on CRLF in the shebang line.
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -39,35 +39,64 @@ flutter build apk --release --dart-define-from-file=.env
 
 Install the APK, connect Spotify in the app, enable the listener service.
 
-### 3. Desktop (Windows)
+### 3. Desktop
 
-The desktop side ships as a pluggable Python package (`like_spotify/`) — tray
-host + default flavor (`tray_hotkey_trigger` + `spotify` provider). The
-broader plugin framework lands across [#19](https://github.com/Osasuwu/like_spotify_mobile_app/issues/19); Phase 1
-tracer is [#21](https://github.com/Osasuwu/like_spotify_mobile_app/issues/21).
+The desktop side ships as a pluggable Python package (`like_spotify/`) —
+a tray host + global hotkey on Windows, a CLI fallback (`like-once`) on
+macOS / Linux, and a multi-backend counter Storage (Supabase or Google
+Sheets).
 
-```bash
+**One-liner installs.** Run from a fresh clone:
+
+```powershell
+# Windows (PowerShell)
 git clone https://github.com/Osasuwu/like_spotify_mobile_app.git
 cd like_spotify_mobile_app
-pipx install -e .           # or: pip install -e .
-
-like-spotify --setup        # interactive Client ID + browser OAuth
-like-spotify                # tray host; default hotkey Ctrl+Shift+Alt+W
+.\install.ps1
 ```
 
-Or build a single-file Windows EXE: `tools\build.bat` →
-`dist\LikeSpotify.exe`.
+```bash
+# macOS / Linux
+git clone https://github.com/Osasuwu/like_spotify_mobile_app.git
+cd like_spotify_mobile_app
+./install.sh
+```
 
-Storage (Supabase counter), best-of promotion, archive-remove, and
-artist-follow land in follow-up issues
-([#22](https://github.com/Osasuwu/like_spotify_mobile_app/issues/22),
-[#23](https://github.com/Osasuwu/like_spotify_mobile_app/issues/23),
-[#26](https://github.com/Osasuwu/like_spotify_mobile_app/issues/26))
-— the tracer bullet does likes only.
+The installer checks for Python 3.11+, installs `pipx` if missing,
+installs the `like-spotify` package, then walks you through the
+interactive setup wizard:
+
+1. **Spotify** — paste a Client ID from
+   [developer.spotify.com/dashboard](https://developer.spotify.com/dashboard)
+   (redirect URI: `http://127.0.0.1:8793/callback`); a browser opens
+   for PKCE OAuth.
+2. **Storage** — pick `supabase`, `sheets`, or `none` (likes work
+   without a counter; you'd just lose cross-device aggregation).
+3. **Autostart** — Windows: toggle the `HKCU\…\Run` entry. macOS /
+   Linux: instructions for a Launch Agent / `.desktop` file are
+   printed (no auto-config — too platform-fragmented).
+
+The wizard is re-runnable; existing tokens are kept unless you pass
+`--reauth` (or `-Reauth` on PowerShell).
+
+**After install:**
+
+```bash
+like-spotify            # Windows: tray host with the hotkey (default Ctrl+Shift+Alt+W)
+like-spotify like-once  # any OS: like the currently-playing track and exit
+like-spotify --config   # print config + token paths
+```
+
+**Single-file `.exe`** (for users without Python): build via
+`tools\build.bat` → `dist\LikeSpotify.exe`.
 
 ### 4. Cross-device counters (optional)
 
-Like counters are shared across devices via [Supabase](https://supabase.com) (free tier).
+Pick a backend during `--setup`:
+
+#### Option A — Supabase (default; one SQL block)
+
+Counters live in Supabase Postgres (free tier).
 
 1. Create a Supabase project
 2. Run the setup SQL:
@@ -95,9 +124,17 @@ Like counters are shared across devices via [Supabase](https://supabase.com) (fr
    ALTER TABLE public.track_likes ENABLE ROW LEVEL SECURITY;
    CREATE POLICY "anon_full_access" ON public.track_likes FOR ALL USING (true) WITH CHECK (true);
    ```
-3. Add `SUPABASE_URL` and `SUPABASE_ANON_KEY` to `.env` (Android). Desktop wiring lands in [#22](https://github.com/Osasuwu/like_spotify_mobile_app/issues/22) (`SupabaseStorage`).
+3. Android: add `SUPABASE_URL` and `SUPABASE_ANON_KEY` to `.env`. Desktop: paste both into the wizard when prompted for the `supabase` backend.
 
-Without Supabase, counters are stored locally per device.
+#### Option B — Google Sheets
+
+If you'd rather see counts in a spreadsheet you control:
+
+1. Create a Google Sheet with header row `user_id | track_id | count | backfilled | updated_at` on a tab named `Likes`. Optionally add an `ArtistTracks` tab for the follow-artist rule.
+2. Create a Google Cloud OAuth client (type: **Desktop app**) at [console.cloud.google.com/apis/credentials](https://console.cloud.google.com/apis/credentials). Enable the Google Sheets API for the project. Note the Client ID + secret.
+3. Run `like-spotify --setup`, pick `sheets`, paste the spreadsheet ID (from the URL), Client ID, and secret. A browser opens for Google authorization — tokens are refreshed automatically afterwards.
+
+Without a backend, counters are silently skipped — likes still write to your Spotify Liked Songs.
 
 ## Architecture
 
@@ -132,7 +169,9 @@ Android (Flutter + Kotlin)          Desktop (Python framework)
 | Trigger pattern / hotkey | In-app UI | `~/.like_spotify/config.json` → `trigger.hotkey` (default `Ctrl+Shift+Alt+W`) |
 | Spotify client_id | `.env` (`SPOTIFY_CLIENT_ID`) | `like-spotify --setup` → `~/.like_spotify/config.json` |
 | Spotify tokens | `FlutterSecureStorage` | `~/.like_spotify/spotify_token.json` |
-| Archive / best-of / follow | In-app UI | (lands in #22 / #23 / #26) |
+| Storage backend | (Supabase only) | `~/.like_spotify/config.json` → `storage.backend` (`supabase` / `sheets` / `none`) |
+| Google Sheets tokens | n/a | `~/.like_spotify/google_token.json` (refreshed automatically) |
+| Archive / best-of / follow | In-app UI | `~/.like_spotify/config.json` → `actions.{archive_remove,promote_to_best_of,follow_artist}` |
 
 ## License
 

--- a/install.ps1
+++ b/install.ps1
@@ -34,15 +34,24 @@ function Write-Warn2($msg){ Write-Host "   warn: $msg" -ForegroundColor Yellow }
 
 Write-Step "Checking for Python >= 3.11"
 
+# Each candidate is (exe, extra-args-array). `py -3` is the py launcher
+# with a version selector; `python` / `python3` are direct shims.
+$candidates = @(
+    @{ exe = "python";  args = @() },
+    @{ exe = "py";      args = @("-3") },
+    @{ exe = "python3"; args = @() }
+)
+
 $python = $null
-foreach ($candidate in @("python", "py -3", "python3")) {
+foreach ($c in $candidates) {
     try {
-        $version = & $candidate.Split(" ")[0] $candidate.Split(" ")[1..($candidate.Split(" ").Count - 1)] --version 2>$null
+        $version = & $c.exe @($c.args + "--version") 2>$null
         if ($LASTEXITCODE -eq 0 -and $version -match "Python (\d+)\.(\d+)") {
             $major = [int]$matches[1]; $minor = [int]$matches[2]
             if ($major -gt 3 -or ($major -eq 3 -and $minor -ge 11)) {
-                $python = $candidate
-                Write-Ok "found $version via '$candidate'"
+                $python = $c
+                $label = if ($c.args) { "$($c.exe) $($c.args -join ' ')" } else { $c.exe }
+                Write-Ok "found $version via '$label'"
                 break
             }
         }

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,107 @@
+<#
+.SYNOPSIS
+    One-liner installer for Like Spotify on Windows.
+
+.DESCRIPTION
+    Checks for Python 3.11+, installs pipx if missing, installs the
+    like-spotify package from this repo, runs the interactive setup
+    wizard. Re-runnable; existing tokens are kept unless -Reauth is
+    passed.
+
+.EXAMPLE
+    iwr https://raw.githubusercontent.com/Osasuwu/like_spotify_mobile_app/main/install.ps1 -OutFile install.ps1
+    .\install.ps1
+
+.EXAMPLE
+    # Re-run OAuth (after revoking access or switching accounts):
+    .\install.ps1 -Reauth
+#>
+
+[CmdletBinding()]
+param(
+    [switch] $Reauth,
+    [switch] $SkipSetup,
+    [string] $Source = "."
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Step($msg) { Write-Host ">> $msg" -ForegroundColor Cyan }
+function Write-Ok($msg)   { Write-Host "   ok: $msg" -ForegroundColor Green }
+function Write-Warn2($msg){ Write-Host "   warn: $msg" -ForegroundColor Yellow }
+
+# ── Python ─────────────────────────────────────────────────────────────
+
+Write-Step "Checking for Python >= 3.11"
+
+$python = $null
+foreach ($candidate in @("python", "py -3", "python3")) {
+    try {
+        $version = & $candidate.Split(" ")[0] $candidate.Split(" ")[1..($candidate.Split(" ").Count - 1)] --version 2>$null
+        if ($LASTEXITCODE -eq 0 -and $version -match "Python (\d+)\.(\d+)") {
+            $major = [int]$matches[1]; $minor = [int]$matches[2]
+            if ($major -gt 3 -or ($major -eq 3 -and $minor -ge 11)) {
+                $python = $candidate
+                Write-Ok "found $version via '$candidate'"
+                break
+            }
+        }
+    } catch {}
+}
+
+if (-not $python) {
+    Write-Host ""
+    Write-Host "Python 3.11+ not found." -ForegroundColor Red
+    Write-Host "Install it from https://www.python.org/downloads/windows/ then re-run this script."
+    Write-Host "Tip: tick 'Add Python to PATH' in the installer."
+    exit 2
+}
+
+# ── pipx ───────────────────────────────────────────────────────────────
+
+Write-Step "Ensuring pipx is available"
+$hasPipx = $false
+try {
+    & pipx --version *>$null
+    if ($LASTEXITCODE -eq 0) { $hasPipx = $true }
+} catch {}
+
+if (-not $hasPipx) {
+    Write-Step "Installing pipx via pip (--user)"
+    & $python.Split(" ")[0] $python.Split(" ")[1..($python.Split(" ").Count - 1)] -m pip install --user --upgrade pipx
+    if ($LASTEXITCODE -ne 0) { throw "pipx install failed" }
+    & $python.Split(" ")[0] $python.Split(" ")[1..($python.Split(" ").Count - 1)] -m pipx ensurepath
+    Write-Warn2 "If 'pipx' isn't on PATH after this, open a new terminal and re-run install.ps1."
+    Write-Ok "pipx installed"
+} else {
+    Write-Ok "pipx already present"
+}
+
+# ── like-spotify ───────────────────────────────────────────────────────
+
+Write-Step "Installing like-spotify from '$Source'"
+& pipx install --force $Source
+if ($LASTEXITCODE -ne 0) { throw "pipx install of like-spotify failed" }
+Write-Ok "like-spotify on PATH"
+
+# ── setup ──────────────────────────────────────────────────────────────
+
+if ($SkipSetup) {
+    Write-Step "Skipping --setup (per -SkipSetup)"
+    Write-Host "Next: run 'like-spotify --setup' manually."
+    exit 0
+}
+
+Write-Step "Launching interactive setup"
+$setupArgs = @("--setup")
+if ($Reauth) { $setupArgs += "--reauth" }
+& like-spotify @setupArgs
+$setupExit = $LASTEXITCODE
+if ($setupExit -ne 0) {
+    Write-Warn2 "setup exited with code $setupExit. Re-run 'like-spotify --setup' once you have the credentials."
+    exit $setupExit
+}
+
+Write-Host ""
+Write-Step "Done. Launch the tray host with: like-spotify"
+Write-Host "      Default hotkey: Ctrl+Shift+Alt+W"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# One-liner installer for Like Spotify on macOS / Linux.
+#
+# Checks for Python 3.11+, installs pipx if missing, installs the
+# like-spotify package from this repo, then runs the interactive setup
+# wizard. Re-runnable; existing tokens are kept unless --reauth is
+# passed.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/Osasuwu/like_spotify_mobile_app/main/install.sh | bash
+#
+#   # Re-run OAuth (after revoking access or switching accounts):
+#   ./install.sh --reauth
+#
+#   # From a local checkout, point at the source dir:
+#   ./install.sh --source /path/to/checkout
+
+set -euo pipefail
+
+REAUTH=0
+SKIP_SETUP=0
+SOURCE="."
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --reauth) REAUTH=1 ;;
+        --skip-setup) SKIP_SETUP=1 ;;
+        --source) SOURCE="$2"; shift ;;
+        -h|--help)
+            sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+step() { printf '\033[1;36m>> %s\033[0m\n' "$*"; }
+ok()   { printf '\033[0;32m   ok: %s\033[0m\n' "$*"; }
+warn() { printf '\033[1;33m   warn: %s\033[0m\n' "$*"; }
+err()  { printf '\033[1;31m   err: %s\033[0m\n' "$*" >&2; }
+
+# ── Python ─────────────────────────────────────────────────────────────
+
+step "Checking for Python >= 3.11"
+PY=""
+for candidate in python3.13 python3.12 python3.11 python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        if "$candidate" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)'; then
+            PY="$candidate"
+            ok "found $($candidate --version 2>&1) via '$candidate'"
+            break
+        fi
+    fi
+done
+
+if [[ -z "$PY" ]]; then
+    err "Python 3.11+ not found."
+    case "$(uname -s)" in
+        Darwin) echo "      Install via: brew install python@3.12" ;;
+        Linux)  echo "      Install via your distro (e.g. apt install python3.12 python3.12-venv)" ;;
+    esac
+    exit 2
+fi
+
+# ── pipx ───────────────────────────────────────────────────────────────
+
+step "Ensuring pipx is available"
+if command -v pipx >/dev/null 2>&1; then
+    ok "pipx already present"
+else
+    step "Installing pipx (user-local)"
+    "$PY" -m pip install --user --upgrade pipx
+    "$PY" -m pipx ensurepath
+    # Try to make it available in the current shell session.
+    export PATH="$HOME/.local/bin:$PATH"
+    if ! command -v pipx >/dev/null 2>&1; then
+        warn "pipx not on PATH yet — open a new shell and re-run install.sh, or add ~/.local/bin to PATH."
+        exit 2
+    fi
+    ok "pipx installed"
+fi
+
+# ── like-spotify ───────────────────────────────────────────────────────
+
+step "Installing like-spotify from '$SOURCE'"
+pipx install --force "$SOURCE"
+ok "like-spotify on PATH"
+
+# ── setup ──────────────────────────────────────────────────────────────
+
+if [[ "$SKIP_SETUP" == "1" ]]; then
+    step "Skipping --setup (per --skip-setup)"
+    echo "Next: run 'like-spotify --setup' manually."
+    exit 0
+fi
+
+step "Launching interactive setup"
+setup_args=(--setup)
+[[ "$REAUTH" == "1" ]] && setup_args+=(--reauth)
+if ! like-spotify "${setup_args[@]}"; then
+    rc=$?
+    warn "setup exited with code $rc. Re-run 'like-spotify --setup' once you have the credentials."
+    exit "$rc"
+fi
+
+echo
+step "Done."
+case "$(uname -s)" in
+    Darwin)
+        echo "       macOS: no resident tray host yet. Use 'like-spotify like-once' to like the current track,"
+        echo "              or bind it to a hotkey via Shortcuts / Karabiner."
+        ;;
+    Linux)
+        echo "       Linux: no resident tray host yet. Use 'like-spotify like-once' to like the current track,"
+        echo "              or bind it to a hotkey via your DE's shortcut settings."
+        ;;
+esac
+echo "       See CONTRIBUTING.md for the hosts/macos.py / linux.py good-first-PR."

--- a/install.sh
+++ b/install.sh
@@ -99,8 +99,11 @@ fi
 step "Launching interactive setup"
 setup_args=(--setup)
 [[ "$REAUTH" == "1" ]] && setup_args+=(--reauth)
-if ! like-spotify "${setup_args[@]}"; then
-    rc=$?
+# Don't use `if ! cmd`: in bash that captures the exit code of `!`, not
+# the command, masking real failures behind a 0 exit. Capture rc directly.
+rc=0
+like-spotify "${setup_args[@]}" || rc=$?
+if [[ "$rc" -ne 0 ]]; then
     warn "setup exited with code $rc. Re-run 'like-spotify --setup' once you have the credentials."
     exit "$rc"
 fi

--- a/like_spotify/auth/__init__.py
+++ b/like_spotify/auth/__init__.py
@@ -1,0 +1,7 @@
+"""Auth helpers shared across hosts/extensions.
+
+Currently only Google's installed-app OAuth lives here; Spotify keeps
+its PKCE flow inside the `spotify` extension because it's also the
+provider. If a second non-provider OAuth flow appears (Last.fm, etc.)
+the pattern is set.
+"""

--- a/like_spotify/auth/google.py
+++ b/like_spotify/auth/google.py
@@ -103,11 +103,25 @@ def authorize(client_id: str, client_secret: str, token_path: Path) -> dict:
         def log_message(self, *_args):
             pass
 
-    server = socketserver.TCPServer(("127.0.0.1", REDIRECT_PORT), Handler)
-    threading.Thread(target=server.handle_request, daemon=True).start()
-    webbrowser.open(url)
-    event.wait(timeout=180)
-    server.server_close()
+    # `allow_reuse_address` lets us re-bind a port that's still in
+    # TIME_WAIT from a previous --setup run on the same shell. Without
+    # it the second invocation crashed `--setup` with a bare OSError.
+    class _ReusableServer(socketserver.TCPServer):
+        allow_reuse_address = True
+
+    try:
+        server = _ReusableServer(("127.0.0.1", REDIRECT_PORT), Handler)
+    except OSError as e:
+        raise AuthError(
+            f"could not bind 127.0.0.1:{REDIRECT_PORT} for the OAuth callback "
+            f"({e}). Close anything using that port and re-run --setup."
+        ) from e
+    try:
+        threading.Thread(target=server.handle_request, daemon=True).start()
+        webbrowser.open(url)
+        event.wait(timeout=180)
+    finally:
+        server.server_close()
 
     if captured["error"]:
         raise AuthError(f"google denied authorization: {captured['error']}")

--- a/like_spotify/auth/google.py
+++ b/like_spotify/auth/google.py
@@ -1,0 +1,217 @@
+"""Google OAuth (installed-app) for the `google_sheets_storage` extension.
+
+Mirrors the Spotify PKCE flow: open browser → loopback HTTP callback →
+authorization-code exchange → persist tokens. Refresh is auto: callers
+get a `token_provider` callable that returns a fresh access token.
+
+Why a separate module: the Spotify extension owns its OAuth because
+it's also the provider, but Google OAuth is reused only at host-wiring
+time — `GoogleSheetsStorage` itself just takes a `() -> str` callable.
+Putting the flow under `like_spotify/auth/` keeps it host-orthogonal
+and reusable if another Google API is wrapped later.
+
+Google requires a `client_secret` even for desktop apps (per the docs),
+but the value is widely known to not be a real secret — it ships with
+the binary in every desktop OAuth client. We persist it next to the
+tokens for refresh; it never appears in logs.
+
+Slice: #28 (folds in the deferred --setup wiring left over from #25).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import http.server
+import json
+import secrets
+import socketserver
+import threading
+import time
+import urllib.parse
+import webbrowser
+from collections.abc import Callable
+from pathlib import Path
+
+import requests
+
+from like_spotify.core.errors import AuthError, TransientError
+
+AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+TOKEN_URL = "https://oauth2.googleapis.com/token"
+SCOPE = "https://www.googleapis.com/auth/spreadsheets"
+
+REDIRECT_PORT = 8794  # +1 vs the Spotify port so both can run in parallel.
+REDIRECT_URI = f"http://127.0.0.1:{REDIRECT_PORT}/callback"
+
+
+def authorize(client_id: str, client_secret: str, token_path: Path) -> dict:
+    """Run the installed-app OAuth flow once. Persists + returns the
+    token bundle (`access_token`, `refresh_token`, `expires_at`).
+
+    Raises `AuthError` if the user cancels / the callback times out.
+    """
+    if not client_id:
+        raise ValueError("google client_id is required")
+    if not client_secret:
+        raise ValueError("google client_secret is required")
+
+    verifier = secrets.token_urlsafe(64)[:96]
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    state = secrets.token_hex(8)
+    params = {
+        "client_id": client_id,
+        "response_type": "code",
+        "redirect_uri": REDIRECT_URI,
+        "scope": SCOPE,
+        "code_challenge_method": "S256",
+        "code_challenge": challenge,
+        "state": state,
+        "access_type": "offline",
+        "prompt": "consent",  # Force refresh_token issuance on re-auth.
+    }
+    url = f"{AUTH_URL}?{urllib.parse.urlencode(params)}"
+
+    captured: dict[str, str | None] = {"code": None, "state": None, "error": None}
+    event = threading.Event()
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            qs = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+            captured["code"] = qs.get("code", [None])[0]
+            captured["state"] = qs.get("state", [None])[0]
+            captured["error"] = qs.get("error", [None])[0]
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            msg = (
+                "Authorized! You can close this tab."
+                if captured["code"]
+                else f"Authorization failed: {captured['error'] or 'no code'}"
+            )
+            self.wfile.write(
+                f"<h2 style='font-family:sans-serif;margin:40px'>{msg}</h2>".encode(
+                    "utf-8"
+                )
+            )
+            event.set()
+
+        def log_message(self, *_args):
+            pass
+
+    server = socketserver.TCPServer(("127.0.0.1", REDIRECT_PORT), Handler)
+    threading.Thread(target=server.handle_request, daemon=True).start()
+    webbrowser.open(url)
+    event.wait(timeout=180)
+    server.server_close()
+
+    if captured["error"]:
+        raise AuthError(f"google denied authorization: {captured['error']}")
+    if not captured["code"]:
+        raise AuthError("google authorization timed out (180s)")
+    if captured["state"] != state:
+        raise AuthError("state mismatch in google OAuth callback")
+
+    r = requests.post(
+        TOKEN_URL,
+        data={
+            "grant_type": "authorization_code",
+            "code": captured["code"],
+            "redirect_uri": REDIRECT_URI,
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "code_verifier": verifier,
+        },
+        timeout=10,
+    )
+    if r.status_code >= 400:
+        raise AuthError(f"google token exchange failed ({r.status_code}): {r.text}")
+    tokens = _augment(r.json())
+    # We persist the (clientid, secret) next to the tokens so a later
+    # refresh from a long-lived host doesn't need them re-prompted.
+    tokens["client_id"] = client_id
+    tokens["client_secret"] = client_secret
+    save_tokens(token_path, tokens)
+    return tokens
+
+
+def load_tokens(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def save_tokens(path: Path, tokens: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(tokens, indent=2), encoding="utf-8")
+
+
+def make_token_provider(token_path: Path) -> Callable[[], str]:
+    """Return a callable that yields a fresh access token, refreshing as
+    needed. Suitable for `GoogleSheetsStorage(token_provider=...)`.
+
+    Thread-safe via a local lock; the storage extension can call this
+    from any of its `asyncio.to_thread` workers without coordination.
+    """
+    lock = threading.Lock()
+    state: dict = load_tokens(token_path)
+
+    def provider() -> str:
+        with lock:
+            if not state.get("refresh_token"):
+                raise AuthError(
+                    "google not authenticated; run `like-spotify --setup` first"
+                )
+            if time.time() > state.get("expires_at", 0) - 60:
+                _refresh(state, token_path)
+            return state["access_token"]
+
+    return provider
+
+
+# ── Internals ──────────────────────────────────────────────────────────
+
+
+def _augment(payload: dict) -> dict:
+    tokens = dict(payload)
+    tokens["expires_at"] = time.time() + tokens.get("expires_in", 3600)
+    return tokens
+
+
+def _refresh(state: dict, token_path: Path) -> None:
+    client_id = state.get("client_id")
+    client_secret = state.get("client_secret")
+    if not client_id or not client_secret:
+        raise AuthError(
+            "google client_id/secret missing from token store; "
+            "re-run `like-spotify --setup --reauth`"
+        )
+    r = requests.post(
+        TOKEN_URL,
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": state["refresh_token"],
+            "client_id": client_id,
+            "client_secret": client_secret,
+        },
+        timeout=10,
+    )
+    if r.status_code in (400, 401):
+        raise AuthError(f"google refresh rejected ({r.status_code}): {r.text}")
+    if r.status_code >= 500:
+        raise TransientError(f"google token endpoint 5xx: {r.status_code}")
+    if r.status_code >= 400:
+        raise AuthError(f"google token refresh failed: {r.status_code} {r.text}")
+    fresh = r.json()
+    state["access_token"] = fresh["access_token"]
+    state["expires_at"] = time.time() + fresh["expires_in"]
+    if "refresh_token" in fresh:
+        state["refresh_token"] = fresh["refresh_token"]
+    save_tokens(token_path, state)

--- a/like_spotify/hosts/_common.py
+++ b/like_spotify/hosts/_common.py
@@ -21,6 +21,7 @@ import os
 import sys
 from pathlib import Path
 
+from like_spotify.auth import google as google_auth
 from like_spotify.core.actions import PostLikeAction
 from like_spotify.core.storage import Storage
 from like_spotify.extensions.archive_remove import (
@@ -28,6 +29,9 @@ from like_spotify.extensions.archive_remove import (
 )
 from like_spotify.extensions.follow_artist import (
     POST_LIKE_ACTION as make_follow_artist_action,
+)
+from like_spotify.extensions.google_sheets_storage import (
+    STORAGE as make_google_sheets_storage,
 )
 from like_spotify.extensions.promote_to_best_of import (
     POST_LIKE_ACTION as make_promote_to_best_of_action,
@@ -45,6 +49,7 @@ def _config_dir() -> Path:
 
 CONFIG_FILE = _config_dir() / "config.json"
 SPOTIFY_TOKEN_FILE = _config_dir() / "spotify_token.json"
+GOOGLE_TOKEN_FILE = _config_dir() / "google_token.json"
 
 
 def load_config() -> dict:
@@ -65,20 +70,54 @@ def save_config(cfg: dict) -> None:
 
 
 def build_storage(cfg: dict) -> Storage | None:
-    """Return a Storage impl iff Supabase is configured; else None.
+    """Return the configured Storage impl, or None when none is wired.
 
-    Acceptance criterion (#22): like still succeeds when storage is
-    unconfigured. Pipeline treats `None` as 'counter silently unavailable'.
+    Selection (set in `cfg["storage"]["backend"]`):
+        - "supabase" → SupabaseStorage (default; back-compat: also picked
+          when `cfg["supabase"]` is populated and no explicit backend).
+        - "sheets"   → GoogleSheetsStorage, backed by tokens persisted
+          in `GOOGLE_TOKEN_FILE` (refreshed automatically).
+        - "none" / missing → None. Pipeline treats `None` as "counter
+          silently unavailable" — AC #22 says like still succeeds.
     """
-    supabase = cfg.get("supabase", {}) if isinstance(cfg.get("supabase"), dict) else {}
-    url = supabase.get("url") or os.environ.get("SUPABASE_URL", "")
-    key = supabase.get("anon_key") or os.environ.get("SUPABASE_ANON_KEY", "")
-    if not url or not key:
-        return None
-    try:
-        return make_supabase_storage(url=url, anon_key=key)
-    except Exception:
-        return None
+    backend = (cfg.get("storage", {}) or {}).get("backend", "")
+
+    # Back-compat for configs written before #28: a populated `supabase`
+    # block implies the user wanted Supabase even though the explicit
+    # `storage.backend` key didn't exist yet.
+    if not backend:
+        sb = cfg.get("supabase", {}) if isinstance(cfg.get("supabase"), dict) else {}
+        if sb.get("url") and sb.get("anon_key"):
+            backend = "supabase"
+
+    if backend == "supabase":
+        sb = cfg.get("supabase", {}) if isinstance(cfg.get("supabase"), dict) else {}
+        url = sb.get("url") or os.environ.get("SUPABASE_URL", "")
+        key = sb.get("anon_key") or os.environ.get("SUPABASE_ANON_KEY", "")
+        if not url or not key:
+            return None
+        try:
+            return make_supabase_storage(url=url, anon_key=key)
+        except Exception:
+            return None
+
+    if backend == "sheets":
+        sheets = cfg.get("sheets", {}) if isinstance(cfg.get("sheets"), dict) else {}
+        sid = sheets.get("spreadsheet_id") or os.environ.get(
+            "GOOGLE_SHEETS_SPREADSHEET_ID", ""
+        )
+        if not sid:
+            return None
+        try:
+            token_provider = google_auth.make_token_provider(GOOGLE_TOKEN_FILE)
+            return make_google_sheets_storage(
+                spreadsheet_id=sid,
+                token_provider=token_provider,
+            )
+        except Exception:
+            return None
+
+    return None
 
 
 def build_post_actions(
@@ -153,39 +192,214 @@ def make_provider(client_id: str):
 # ── Interactive setup ──────────────────────────────────────────────────
 
 
-def do_setup() -> int:
-    """Interactive Client ID + browser OAuth.
+def _prompt(label: str, *, default: str = "", required: bool = False) -> str:
+    hint = f" [{default}]" if default else (" [required]" if required else "")
+    entered = input(f"{label}{hint}: ").strip()
+    value = entered or default
+    if required and not value:
+        raise _SetupAbort(f"{label} is required")
+    return value
 
-    Shared between hosts so `like-spotify --setup` behaves identically on
-    every platform.
+
+def _prompt_secret(label: str, *, current: str = "") -> str:
+    """Prompt with a masked preview of the current value (if any).
+
+    `getpass`-style hiding isn't worth it here — `--setup` runs in a
+    terminal the user controls, and the value is then written to a
+    plaintext config file anyway. The mask is just to keep shoulder-
+    surfing-friendly diffs out of `--config` output.
+    """
+    preview = (current[:4] + "…") if current else "required"
+    entered = input(f"{label} [{preview}]: ").strip()
+    return entered or current
+
+
+def _prompt_choice(
+    label: str, choices: list[str], default: str
+) -> str:
+    options = "/".join(c if c != default else f"{c}*" for c in choices)
+    while True:
+        entered = input(f"{label} [{options}]: ").strip().lower()
+        value = entered or default
+        if value in choices:
+            return value
+        print(f"  pick one of {', '.join(choices)}", file=sys.stderr)
+
+
+def _prompt_yes_no(label: str, *, default: bool) -> bool:
+    suffix = "[Y/n]" if default else "[y/N]"
+    entered = input(f"{label} {suffix}: ").strip().lower()
+    if not entered:
+        return default
+    return entered.startswith("y")
+
+
+class _SetupAbort(Exception):
+    """User-facing setup failure — caught by `do_setup`."""
+
+
+def do_setup(reauth: bool = False) -> int:
+    """Interactive wizard: Spotify OAuth → storage choice → autostart.
+
+    Re-runnable. Existing tokens are kept unless `--reauth` is passed
+    or the user picks a different storage backend.
     """
     print("Like Spotify — interactive setup")
     print("--------------------------------")
     cfg = load_config()
-    current = cfg.get("spotify", {}).get("client_id", "")
-    prompt = f"Spotify Client ID [{current[:6] + '…' if current else 'required'}]: "
-    entered = input(prompt).strip()
-    client_id = entered or current
-    if not client_id:
-        print("Aborted: client_id is required.", file=sys.stderr)
-        print(
-            "Get one at https://developer.spotify.com/dashboard and add the redirect URI "
-            "http://127.0.0.1:8793/callback to the app.",
-            file=sys.stderr,
-        )
+    try:
+        _setup_spotify(cfg, reauth=reauth)
+        _setup_storage(cfg, reauth=reauth)
+        _setup_autostart()
+    except _SetupAbort as e:
+        print(f"Aborted: {e}", file=sys.stderr)
         return 2
+    except KeyboardInterrupt:
+        print("\nAborted by user.", file=sys.stderr)
+        return 130
 
-    cfg.setdefault("spotify", {})["client_id"] = client_id
-    cfg.setdefault("trigger", {}).setdefault("hotkey", DEFAULT_HOTKEY)
     save_config(cfg)
-    print(f"Config saved: {CONFIG_FILE}")
-
-    print("Opening browser for Spotify authorization (PKCE)…")
-    provider = make_provider(client_id)
-    provider.authorize()
-    print(f"Tokens saved: {SPOTIFY_TOKEN_FILE}")
+    print(f"\nConfig saved: {CONFIG_FILE}")
     print("Done. Launch with: like-spotify")
     return 0
+
+
+# ── Wizard steps ───────────────────────────────────────────────────────
+
+
+def _setup_spotify(cfg: dict, *, reauth: bool) -> None:
+    print("\n[1/3] Spotify")
+    current_id = cfg.get("spotify", {}).get("client_id", "")
+    client_id = _prompt_secret("  Client ID", current=current_id)
+    if not client_id:
+        raise _SetupAbort(
+            "Spotify Client ID is required. Get one at "
+            "https://developer.spotify.com/dashboard "
+            "(redirect URI: http://127.0.0.1:8793/callback)."
+        )
+    cfg.setdefault("spotify", {})["client_id"] = client_id
+    cfg.setdefault("trigger", {}).setdefault("hotkey", DEFAULT_HOTKEY)
+    # Persist now so a later step's failure doesn't lose the client id.
+    save_config(cfg)
+
+    provider = make_provider(client_id)
+    if provider.has_tokens and not reauth:
+        print("  ✓ Spotify tokens already saved — skipping browser auth")
+        print("    (use --reauth to force a re-login)")
+        return
+    print("  Opening browser for Spotify authorization (PKCE)…")
+    provider.authorize()
+    print(f"  ✓ Tokens saved: {SPOTIFY_TOKEN_FILE}")
+
+
+def _setup_storage(cfg: dict, *, reauth: bool) -> None:
+    print("\n[2/3] Storage (counts likes across devices)")
+    current_backend = (cfg.get("storage", {}) or {}).get("backend", "")
+    default = current_backend or "none"
+    backend = _prompt_choice(
+        "  Backend", choices=["supabase", "sheets", "none"], default=default
+    )
+    cfg.setdefault("storage", {})["backend"] = backend
+
+    if backend == "supabase":
+        sb = cfg.setdefault("supabase", {})
+        sb["url"] = _prompt_secret("  Supabase URL", current=sb.get("url", ""))
+        sb["anon_key"] = _prompt_secret(
+            "  Supabase anon key", current=sb.get("anon_key", "")
+        )
+        if not sb["url"] or not sb["anon_key"]:
+            raise _SetupAbort("supabase URL + anon key are both required")
+        print("  ✓ Supabase configured")
+    elif backend == "sheets":
+        sheets = cfg.setdefault("sheets", {})
+        sheets["spreadsheet_id"] = _prompt_secret(
+            "  Spreadsheet ID (from the sheet URL)",
+            current=sheets.get("spreadsheet_id", ""),
+        )
+        if not sheets["spreadsheet_id"]:
+            raise _SetupAbort("spreadsheet ID is required for sheets backend")
+
+        tokens = google_auth.load_tokens(GOOGLE_TOKEN_FILE)
+        if tokens.get("refresh_token") and not reauth:
+            print("  ✓ Google tokens already saved — skipping browser auth")
+            print("    (use --reauth to force a re-login)")
+        else:
+            client_id = _prompt_secret(
+                "  Google OAuth Client ID (Desktop app)",
+                current=tokens.get("client_id", ""),
+            )
+            client_secret = _prompt_secret(
+                "  Google OAuth Client Secret",
+                current=tokens.get("client_secret", ""),
+            )
+            if not client_id or not client_secret:
+                raise _SetupAbort(
+                    "google client id + secret are both required "
+                    "(create a Desktop OAuth client at "
+                    "https://console.cloud.google.com/apis/credentials)"
+                )
+            print("  Opening browser for Google authorization…")
+            google_auth.authorize(
+                client_id=client_id,
+                client_secret=client_secret,
+                token_path=GOOGLE_TOKEN_FILE,
+            )
+            print(f"  ✓ Google tokens saved: {GOOGLE_TOKEN_FILE}")
+    else:
+        print("  ✓ Counter disabled — likes still work, no count tracking.")
+
+
+def _setup_autostart() -> None:
+    print("\n[3/3] Autostart")
+    if sys.platform != "win32":
+        # Print instructions only — issue AC: no auto-config on mac/linux.
+        if sys.platform == "darwin":
+            print(
+                "  macOS: add a Launch Agent to start at login. Example "
+                "(write to ~/Library/LaunchAgents/com.osasuwu.like-spotify.plist):"
+            )
+            print(
+                '    <plist version="1.0"><dict>'
+                '<key>Label</key><string>com.osasuwu.like-spotify</string>'
+                '<key>ProgramArguments</key><array>'
+                '<string>like-spotify</string><string>like-once</string>'
+                '</array>'
+                '<key>RunAtLoad</key><true/></dict></plist>'
+            )
+            print("    then: launchctl load ~/Library/LaunchAgents/com.osasuwu.like-spotify.plist")
+        else:
+            print(
+                "  Linux: drop a .desktop entry into ~/.config/autostart/, e.g.\n"
+                "    [Desktop Entry]\n"
+                "    Type=Application\n"
+                "    Exec=like-spotify like-once\n"
+                "    Hidden=false\n"
+                "    NoDisplay=false\n"
+                "    Name=Like Spotify"
+            )
+        print("  (See CONTRIBUTING.md for the full hosts/macos.py / linux.py story.)")
+        return
+
+    # Windows: prompt to toggle the registry Run key.
+    try:
+        from like_spotify.hosts import windows as _win
+
+        already = _win._autostart_enabled()
+    except Exception:
+        print("  (could not query autostart — skip)", file=sys.stderr)
+        return
+
+    label = (
+        "  Autostart is currently ENABLED — keep it on?"
+        if already
+        else "  Start Like Spotify when you log in to Windows?"
+    )
+    if _prompt_yes_no(label, default=True):
+        _win._autostart_set(True)
+        print("  ✓ Autostart enabled (HKCU\\…\\Run)")
+    else:
+        _win._autostart_set(False)
+        print("  ✓ Autostart disabled")
 
 
 # ── CLI ────────────────────────────────────────────────────────────────
@@ -215,7 +429,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "like-once — perform a single like and exit."
         ),
     )
-    p.add_argument("--setup", action="store_true", help="Interactive Client ID + browser OAuth.")
+    p.add_argument("--setup", action="store_true", help="Interactive setup wizard.")
+    p.add_argument(
+        "--reauth",
+        action="store_true",
+        help=(
+            "With --setup: re-run OAuth even if valid tokens are present "
+            "(use after revoking access or switching accounts)."
+        ),
+    )
     p.add_argument("--config", action="store_true", help="Print config / token paths.")
     return p.parse_args(argv)
 
@@ -223,6 +445,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 def print_config_paths() -> int:
     print(f"Config:        {CONFIG_FILE}")
     print(f"Spotify token: {SPOTIFY_TOKEN_FILE}")
+    print(f"Google token:  {GOOGLE_TOKEN_FILE}")
     return 0
 
 

--- a/like_spotify/hosts/_common.py
+++ b/like_spotify/hosts/_common.py
@@ -82,12 +82,16 @@ def build_storage(cfg: dict) -> Storage | None:
     """
     backend = (cfg.get("storage", {}) or {}).get("backend", "")
 
-    # Back-compat for configs written before #28: a populated `supabase`
-    # block implies the user wanted Supabase even though the explicit
-    # `storage.backend` key didn't exist yet.
+    # Back-compat for configs written before #28:
+    #   - a populated `supabase` block implies Supabase
+    #   - OR SUPABASE_URL + SUPABASE_ANON_KEY env vars alone (the pre-#28
+    #     Android / CI path) — keep this working so existing deployments
+    #     don't regress when they upgrade.
     if not backend:
         sb = cfg.get("supabase", {}) if isinstance(cfg.get("supabase"), dict) else {}
         if sb.get("url") and sb.get("anon_key"):
+            backend = "supabase"
+        elif os.environ.get("SUPABASE_URL") and os.environ.get("SUPABASE_ANON_KEY"):
             backend = "supabase"
 
     if backend == "supabase":
@@ -241,8 +245,10 @@ class _SetupAbort(Exception):
 def do_setup(reauth: bool = False) -> int:
     """Interactive wizard: Spotify OAuth → storage choice → autostart.
 
-    Re-runnable. Existing tokens are kept unless `--reauth` is passed
-    or the user picks a different storage backend.
+    Re-runnable. Existing OAuth tokens (Spotify, Google) are kept unless
+    `reauth=True` is passed — switching storage backend does NOT
+    invalidate the other backend's tokens, so a user can flip
+    supabase ↔ sheets without redoing OAuth.
     """
     print("Like Spotify — interactive setup")
     print("--------------------------------")

--- a/like_spotify/hosts/_stub.py
+++ b/like_spotify/hosts/_stub.py
@@ -115,7 +115,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.config:
         return _common.print_config_paths()
     if args.setup:
-        return _common.do_setup()
+        return _common.do_setup(reauth=args.reauth)
 
     if args.command == "like-once":
         return _run_like_once()

--- a/like_spotify/hosts/windows.py
+++ b/like_spotify/hosts/windows.py
@@ -216,7 +216,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.config:
         return _common.print_config_paths()
     if args.setup:
-        return _common.do_setup()
+        return _common.do_setup(reauth=args.reauth)
     if args.command == "like-once":
         return _run_like_once()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Issues    = "https://github.com/Osasuwu/like_spotify_mobile_app/issues"
 
 [tool.setuptools.packages.find]
 include = ["like_spotify*"]
-exclude = ["tests*"]
+exclude = ["tests*", ".venv-build*"]
 
 [tool.setuptools.package-data]
 "like_spotify.extensions.archive_remove" = ["manifest.json"]

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -1,0 +1,145 @@
+"""Unit tests for `like_spotify.auth.google`.
+
+Slice: #28 — the OAuth flow itself is exercised only at its
+`requests.post` boundary; the loopback HTTP callback + browser open
+flow needs real OS surfaces and lives behind an integration test.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from like_spotify.auth import google as google_auth
+from like_spotify.core.errors import AuthError, TransientError
+
+
+# ── Token persistence ──────────────────────────────────────────────────
+
+
+def test_save_and_load_tokens_roundtrip(tmp_path) -> None:
+    path = tmp_path / "google.json"
+    google_auth.save_tokens(path, {"refresh_token": "rt", "access_token": "at"})
+    loaded = google_auth.load_tokens(path)
+    assert loaded["refresh_token"] == "rt"
+    assert loaded["access_token"] == "at"
+
+
+def test_load_tokens_missing_returns_empty_dict(tmp_path) -> None:
+    assert google_auth.load_tokens(tmp_path / "missing.json") == {}
+
+
+def test_load_tokens_corrupt_returns_empty_dict(tmp_path) -> None:
+    path = tmp_path / "google.json"
+    path.write_text("{not-json")
+    assert google_auth.load_tokens(path) == {}
+
+
+# ── make_token_provider() ──────────────────────────────────────────────
+
+
+def _write_tokens(path: Path, **overrides) -> None:
+    base = {
+        "access_token": "at-cached",
+        "refresh_token": "rt",
+        "expires_at": time.time() + 3600,
+        "client_id": "cid",
+        "client_secret": "sec",
+    }
+    base.update(overrides)
+    google_auth.save_tokens(path, base)
+
+
+def test_provider_returns_cached_token_when_not_expired(tmp_path) -> None:
+    path = tmp_path / "g.json"
+    _write_tokens(path)
+    provider = google_auth.make_token_provider(path)
+    assert provider() == "at-cached"
+
+
+def test_provider_refreshes_when_expired(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "g.json"
+    _write_tokens(path, expires_at=time.time() - 10)
+
+    fake_response = MagicMock(status_code=200)
+    fake_response.json.return_value = {"access_token": "at-fresh", "expires_in": 3600}
+    post = MagicMock(return_value=fake_response)
+    monkeypatch.setattr(google_auth.requests, "post", post)
+
+    provider = google_auth.make_token_provider(path)
+    token = provider()
+
+    assert token == "at-fresh"
+    post.assert_called_once()
+    body = post.call_args.kwargs["data"]
+    assert body["grant_type"] == "refresh_token"
+    assert body["refresh_token"] == "rt"
+    assert body["client_id"] == "cid"
+    assert body["client_secret"] == "sec"
+
+    # New token is persisted, so a second call doesn't hit the network.
+    post.reset_mock()
+    assert provider() == "at-fresh"
+    post.assert_not_called()
+
+
+def test_provider_no_refresh_token_raises_authn_error(tmp_path) -> None:
+    path = tmp_path / "g.json"
+    google_auth.save_tokens(path, {})
+    provider = google_auth.make_token_provider(path)
+    with pytest.raises(AuthError, match="not authenticated"):
+        provider()
+
+
+def test_provider_refresh_400_raises_auth_error(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "g.json"
+    _write_tokens(path, expires_at=time.time() - 10)
+
+    post = MagicMock(return_value=MagicMock(status_code=400, text="bad refresh"))
+    monkeypatch.setattr(google_auth.requests, "post", post)
+
+    provider = google_auth.make_token_provider(path)
+    with pytest.raises(AuthError, match="rejected"):
+        provider()
+
+
+def test_provider_refresh_5xx_raises_transient(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "g.json"
+    _write_tokens(path, expires_at=time.time() - 10)
+
+    post = MagicMock(return_value=MagicMock(status_code=503, text="oops"))
+    monkeypatch.setattr(google_auth.requests, "post", post)
+
+    provider = google_auth.make_token_provider(path)
+    with pytest.raises(TransientError):
+        provider()
+
+
+def test_provider_missing_client_secret_in_store_raises(tmp_path) -> None:
+    """Token store written by an older flow has no client_id/secret —
+    refresh needs them, so we tell the user how to recover."""
+    path = tmp_path / "g.json"
+    _write_tokens(path, expires_at=time.time() - 10, client_id="", client_secret="")
+    provider = google_auth.make_token_provider(path)
+    with pytest.raises(AuthError, match="--reauth"):
+        provider()
+
+
+# ── authorize() input validation ───────────────────────────────────────
+
+
+def test_authorize_rejects_empty_client_id(tmp_path) -> None:
+    with pytest.raises(ValueError, match="client_id"):
+        google_auth.authorize(
+            client_id="", client_secret="sec", token_path=tmp_path / "g.json"
+        )
+
+
+def test_authorize_rejects_empty_client_secret(tmp_path) -> None:
+    with pytest.raises(ValueError, match="client_secret"):
+        google_auth.authorize(
+            client_id="cid", client_secret="", token_path=tmp_path / "g.json"
+        )

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,0 +1,312 @@
+"""Setup wizard + storage dispatch tests.
+
+Slice: #28 (one-liner install + interactive --setup + autostart).
+
+Covers the wizard branches (re-runnable, --reauth, storage backend
+choice, autostart) and the multi-backend `build_storage` dispatch.
+The real OAuth flows (Spotify PKCE, Google installed-app) are not
+exercised — they hit a real browser + network; the wizard mocks the
+provider/storage factories at their boundaries.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from like_spotify.hosts import _common
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_paths(tmp_path, monkeypatch) -> Iterator[Path]:
+    """Redirect all host I/O at a writable tmp dir."""
+    cfg = tmp_path / "config.json"
+    spotify = tmp_path / "spotify_token.json"
+    google = tmp_path / "google_token.json"
+    monkeypatch.setattr(_common, "CONFIG_FILE", cfg)
+    monkeypatch.setattr(_common, "SPOTIFY_TOKEN_FILE", spotify)
+    monkeypatch.setattr(_common, "GOOGLE_TOKEN_FILE", google)
+    yield tmp_path
+
+
+class _FakeProvider:
+    """Stand-in for SpotifyMusicProvider used during setup."""
+
+    def __init__(self, has_tokens: bool = False) -> None:
+        self._has = has_tokens
+        self.authorize_calls = 0
+
+    @property
+    def has_tokens(self) -> bool:
+        return self._has
+
+    def authorize(self) -> None:
+        self.authorize_calls += 1
+        self._has = True
+
+
+@pytest.fixture
+def fake_provider(monkeypatch) -> _FakeProvider:
+    fp = _FakeProvider()
+    monkeypatch.setattr(_common, "make_provider", lambda _client_id: fp)
+    return fp
+
+
+def _scripted_input(answers: list[str]):
+    """Returns a callable substitute for `input` that pops answers in order.
+
+    If the wizard prompts more than scripted, fail fast — that's a real
+    drift in the wizard, not a test bug.
+    """
+    answers = list(answers)
+
+    def _input(prompt: str = "") -> str:
+        if not answers:
+            raise AssertionError(f"wizard asked for more input than scripted: {prompt!r}")
+        return answers.pop(0)
+
+    return _input
+
+
+# ── do_setup happy path: Spotify + Supabase + no autostart ─────────────
+
+
+def test_setup_supabase_writes_config_and_runs_oauth(
+    tmp_paths, fake_provider, monkeypatch
+) -> None:
+    answers = [
+        "abc123client",        # Spotify Client ID
+        "supabase",            # Storage backend
+        "https://x.supabase.co",  # Supabase URL
+        "anon-key-xyz",        # Supabase anon key
+        # autostart prompt only fires on win32 — we patch sys.platform off
+    ]
+    monkeypatch.setattr("builtins.input", _scripted_input(answers))
+    monkeypatch.setattr(_common.sys, "platform", "darwin")
+
+    rc = _common.do_setup(reauth=False)
+    assert rc == 0
+
+    cfg = _common.load_config()
+    assert cfg["spotify"]["client_id"] == "abc123client"
+    assert cfg["storage"]["backend"] == "supabase"
+    assert cfg["supabase"]["url"] == "https://x.supabase.co"
+    assert cfg["supabase"]["anon_key"] == "anon-key-xyz"
+    assert fake_provider.authorize_calls == 1
+
+
+def test_setup_skips_spotify_oauth_when_tokens_present(
+    tmp_paths, monkeypatch
+) -> None:
+    fp = _FakeProvider(has_tokens=True)
+    monkeypatch.setattr(_common, "make_provider", lambda _cid: fp)
+    monkeypatch.setattr("builtins.input", _scripted_input([
+        "abc123client",
+        "none",
+    ]))
+    monkeypatch.setattr(_common.sys, "platform", "linux")
+
+    rc = _common.do_setup(reauth=False)
+    assert rc == 0
+    assert fp.authorize_calls == 0  # tokens already there
+
+
+def test_setup_reauth_forces_oauth_even_with_tokens(
+    tmp_paths, monkeypatch
+) -> None:
+    fp = _FakeProvider(has_tokens=True)
+    monkeypatch.setattr(_common, "make_provider", lambda _cid: fp)
+    monkeypatch.setattr("builtins.input", _scripted_input([
+        "abc123client",
+        "none",
+    ]))
+    monkeypatch.setattr(_common.sys, "platform", "linux")
+
+    rc = _common.do_setup(reauth=True)
+    assert rc == 0
+    assert fp.authorize_calls == 1
+
+
+def test_setup_aborts_when_client_id_missing(
+    tmp_paths, fake_provider, monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr("builtins.input", _scripted_input([""]))
+    monkeypatch.setattr(_common.sys, "platform", "linux")
+
+    rc = _common.do_setup(reauth=False)
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "Client ID is required" in err
+
+
+def test_setup_storage_none_writes_backend_marker(
+    tmp_paths, fake_provider, monkeypatch
+) -> None:
+    monkeypatch.setattr("builtins.input", _scripted_input([
+        "abc123client",
+        "none",
+    ]))
+    monkeypatch.setattr(_common.sys, "platform", "linux")
+
+    rc = _common.do_setup(reauth=False)
+    assert rc == 0
+    cfg = _common.load_config()
+    assert cfg["storage"]["backend"] == "none"
+    # No supabase / sheets blocks created.
+    assert "supabase" not in cfg or not cfg.get("supabase")
+    assert "sheets" not in cfg or not cfg.get("sheets")
+
+
+def test_setup_aborts_when_supabase_creds_blank(
+    tmp_paths, fake_provider, monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr("builtins.input", _scripted_input([
+        "abc123client",
+        "supabase",
+        "",  # empty URL
+        "",  # empty anon key
+    ]))
+    monkeypatch.setattr(_common.sys, "platform", "linux")
+
+    rc = _common.do_setup(reauth=False)
+    assert rc == 2
+    assert "supabase" in capsys.readouterr().err.lower()
+
+
+def test_setup_sheets_branch_runs_google_oauth(
+    tmp_paths, fake_provider, monkeypatch
+) -> None:
+    monkeypatch.setattr("builtins.input", _scripted_input([
+        "abc123client",
+        "sheets",
+        "spreadsheet-id-xyz",
+        "google-client.apps.googleusercontent.com",
+        "google-secret",
+    ]))
+    monkeypatch.setattr(_common.sys, "platform", "linux")
+
+    calls: dict = {}
+
+    def fake_google_authorize(*, client_id, client_secret, token_path):
+        calls["client_id"] = client_id
+        calls["client_secret"] = client_secret
+        calls["token_path"] = token_path
+        # Pretend the OAuth flow wrote a refresh token to disk.
+        token_path.write_text('{"refresh_token": "rt", "access_token": "at"}')
+        return {"refresh_token": "rt", "access_token": "at"}
+
+    monkeypatch.setattr(_common.google_auth, "authorize", fake_google_authorize)
+
+    rc = _common.do_setup(reauth=False)
+    assert rc == 0
+
+    cfg = _common.load_config()
+    assert cfg["storage"]["backend"] == "sheets"
+    assert cfg["sheets"]["spreadsheet_id"] == "spreadsheet-id-xyz"
+    assert calls["client_id"] == "google-client.apps.googleusercontent.com"
+    assert calls["client_secret"] == "google-secret"
+    assert calls["token_path"] == _common.GOOGLE_TOKEN_FILE
+
+
+def test_setup_sheets_skips_google_oauth_when_refresh_token_present(
+    tmp_paths, fake_provider, monkeypatch
+) -> None:
+    """If google_token.json already has a refresh_token, the wizard should
+    not re-prompt for client_id/secret and not call `authorize`."""
+    _common.GOOGLE_TOKEN_FILE.write_text(
+        '{"refresh_token": "rt", "access_token": "at",'
+        ' "client_id": "old", "client_secret": "old"}'
+    )
+
+    monkeypatch.setattr("builtins.input", _scripted_input([
+        "abc123client",
+        "sheets",
+        "spreadsheet-id-xyz",
+        # NO client_id/secret prompts because refresh_token is present.
+    ]))
+    monkeypatch.setattr(_common.sys, "platform", "linux")
+
+    called = {"n": 0}
+
+    def fake_google_authorize(**_kw):
+        called["n"] += 1
+
+    monkeypatch.setattr(_common.google_auth, "authorize", fake_google_authorize)
+
+    rc = _common.do_setup(reauth=False)
+    assert rc == 0
+    assert called["n"] == 0
+
+
+# ── build_storage dispatch ─────────────────────────────────────────────
+
+
+def test_build_storage_supabase_backend(tmp_paths) -> None:
+    storage = _common.build_storage({
+        "storage": {"backend": "supabase"},
+        "supabase": {"url": "https://x.supabase.co", "anon_key": "k"},
+    })
+    assert storage is not None
+    assert type(storage).__name__ == "SupabaseStorage"
+
+
+def test_build_storage_supabase_back_compat_legacy_config(tmp_paths) -> None:
+    """Configs written before #28 only have a `supabase` block, no
+    `storage.backend` marker. They must keep working."""
+    storage = _common.build_storage({
+        "supabase": {"url": "https://x.supabase.co", "anon_key": "k"},
+    })
+    assert storage is not None
+    assert type(storage).__name__ == "SupabaseStorage"
+
+
+def test_build_storage_sheets_backend(tmp_paths) -> None:
+    _common.GOOGLE_TOKEN_FILE.write_text(
+        '{"refresh_token": "rt", "access_token": "at",'
+        ' "expires_at": 9999999999,'
+        ' "client_id": "cid", "client_secret": "sec"}'
+    )
+    storage = _common.build_storage({
+        "storage": {"backend": "sheets"},
+        "sheets": {"spreadsheet_id": "sid"},
+    })
+    assert storage is not None
+    assert type(storage).__name__ == "GoogleSheetsStorage"
+
+
+def test_build_storage_none_backend_returns_none(tmp_paths) -> None:
+    assert _common.build_storage({"storage": {"backend": "none"}}) is None
+
+
+def test_build_storage_missing_supabase_creds_returns_none(tmp_paths) -> None:
+    """Acceptance criterion #22: like still succeeds when storage is
+    unconfigured. The host must not crash on a half-filled supabase block."""
+    assert (
+        _common.build_storage({
+            "storage": {"backend": "supabase"},
+            "supabase": {"url": ""},
+        })
+        is None
+    )
+
+
+def test_build_storage_missing_spreadsheet_id_returns_none(tmp_paths) -> None:
+    assert _common.build_storage({"storage": {"backend": "sheets"}}) is None
+
+
+# ── print_config_paths surfaces all three paths ────────────────────────
+
+
+def test_print_config_paths_includes_google_token(tmp_paths, capsys) -> None:
+    rc = _common.print_config_paths()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Config:" in out
+    assert "Spotify token:" in out
+    assert "Google token:" in out

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -266,6 +266,18 @@ def test_build_storage_supabase_back_compat_legacy_config(tmp_paths) -> None:
     assert type(storage).__name__ == "SupabaseStorage"
 
 
+def test_build_storage_supabase_back_compat_env_vars_only(
+    tmp_paths, monkeypatch
+) -> None:
+    """Pre-#28: only env vars (no config block at all) was a supported
+    deploy path. The dispatcher must keep that working."""
+    monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "k")
+    storage = _common.build_storage({})
+    assert storage is not None
+    assert type(storage).__name__ == "SupabaseStorage"
+
+
 def test_build_storage_sheets_backend(tmp_paths) -> None:
     _common.GOOGLE_TOKEN_FILE.write_text(
         '{"refresh_token": "rt", "access_token": "at",'


### PR DESCRIPTION
## Summary

- One-liner installers: `install.ps1` (Windows) and `install.sh` (mac/Linux). Both check Python 3.11+, install pipx if missing, install the package, then run the interactive setup wizard. `--reauth` / `-Reauth` forces a fresh OAuth round.
- `--setup` is now a 3-step wizard (Spotify → Storage backend → Autostart). Re-runnable; existing tokens are kept unless `--reauth` is passed.
- Storage choice exposed at setup time: `supabase` | `sheets` | `none`. `build_storage()` is a multi-backend dispatcher with back-compat for pre-#28 configs.
- New module `like_spotify/auth/google.py` — Google installed-app OAuth (PKCE + loopback callback, same shape as Spotify) + a thread-safe `make_token_provider()` that auto-refreshes. The host wires the chosen backend automatically; `GoogleSheetsStorage` keeps its existing `token_provider` injection point.
- README quick-start updated with the one-liners and the new Sheets option.

## Acceptance criteria

### #28

- [x] `--setup` re-runnable; does not overwrite existing valid OAuth tokens unless `--reauth` is passed. Covered by `test_setup_skips_spotify_oauth_when_tokens_present` + `test_setup_reauth_forces_oauth_even_with_tokens` + `test_setup_sheets_skips_google_oauth_when_refresh_token_present`.
- [x] Autostart: Windows toggles HKCU\…\Run (existing logic in `hosts/windows.py`); mac/Linux print Launch Agent / `.desktop` instructions, no auto-config.
- [x] PyInstaller `.exe` path retained: `tools/build.bat` + `tools/LikeSpotify.spec` still drive the same `LikeSpotify.exe` (no spec changes needed beyond #27's manifest additions).
- [x] README quick-start uses the one-liners.
- [ ] Smoke on a clean Windows VM — manual verification: `iwr ... -OutFile install.ps1 ; .\install.ps1` → tray running with the hotkey at the end.
- [ ] Smoke on a clean macOS / Linux box — manual: `bash install.sh` → CLI works, autostart instructions printed.

### #25 (folds in here)

- [x] User picks `sheets` in `--setup` → walks Google OAuth → like flow writes/updates rows in the chosen sheet. (Wizard + `build_storage` + `GoogleSheetsStorage` already pass the shared contract suite.)
- [x] Sheets impl honors the `was_already_liked` backfill flag from #24 (verified by the existing storage contract tests).
- [x] Both Supabase and Sheets impls pass the same Storage contract test suite (`tests/test_storage_contract.py` — already green pre-#28).

## Test plan

- [x] `pytest` — 122 pass (96 baseline + 26 new). New: 15 wizard branches + 11 google_auth.
- [x] `like-spotify --setup --reauth` parses correctly.
- [x] `bash -n install.sh` — clean shell syntax.
- [ ] Manual Windows install end-to-end on a fresh user account.
- [ ] Manual macOS install end-to-end (`like-once` likes the playing track).

## Out of scope

- Real macOS / Linux **tray** hosts (`hosts/macos.py`, `hosts/linux.py`) — flagged in CONTRIBUTING.md as good-first-PR. The stub host handles `like-once` + `--setup` + `--config` on those platforms, which is what #28 ACs require.

Closes #28. Finishes the deferred `--setup` wiring from #25 (which was partial-merged via #38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)