### PR TITLE
docs: discoverability — comparison table, plugin-author guide, VolumeButtonTrigger skeleton (closes #29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,14 @@ app.*.map.json
 __pycache__/
 *.egg-info/
 .pytest_cache/
-/dist/
+.coverage
+htmlcov/
+**/dist/
+**/build/
 tools/build/
 tools/dist/
+
+# Python virtualenvs (devs may scaffold a build venv at the repo root)
+.venv/
+.venv-*/
+venv/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,20 +87,275 @@ Same shape as macOS:
 - **`PostLikeAction` impls** — anything that wants to react to a like.
   Mood tagging, last.fm scrobble fix-up, "send to a friend's queue", etc.
 
-## Adding an extension
+## Plugin-author guide
 
-1. Create `like_spotify/extensions/<your_thing>/__init__.py` with the
-   concrete class and a top-level factory named after the extension
-   point — `TRIGGER`, `MUSIC_PROVIDER`, `STORAGE`,
-   `PRE_LIKE_ACTION`, or `POST_LIKE_ACTION`.
-2. Create `manifest.json` next to it (see existing extensions for the
-   schema — `domain`, `extension_point`, `name`, `description`,
-   `requirements`, `stage`).
-3. Register the manifest file in `pyproject.toml`'s
-   `[tool.setuptools.package-data]` block.
-4. Add tests under `tests/`. For `Storage`, run the shared contract
-   suite from `tests/test_storage_contract.py`. For everything else,
-   small async unit tests against the interface are enough.
+The desktop framework has five extension points. Each one is a small
+ABC under `like_spotify/core/`; concrete impls live in
+`like_spotify/extensions/<your_domain>/`. The host discovers extensions
+via a filesystem convention (manifest + module-level factory) —
+modelled on Music Assistant's provider layout, with a typed-base per
+seam instead of a single generic `Plugin` (see
+[docs/design/interfaces.md](docs/design/interfaces.md) §1 for the
+prior-art comparison and why we chose this shape over Pano's closed
+enum or MA's single-bag plugin).
+
+### Anatomy of an extension
+
+Every extension folder has the same shape:
+
+```
+like_spotify/extensions/<your_domain>/
+├── __init__.py     # the class + a module-level factory
+└── manifest.json   # static metadata for the host
+```
+
+The factory name is fixed per extension point — `TRIGGER`,
+`MUSIC_PROVIDER`, `STORAGE`, `PRE_LIKE_ACTION`, or `POST_LIKE_ACTION`
+— and it's a plain callable that returns one configured instance.
+The host imports the package and calls the factory with whatever
+kwargs the manifest declares.
+
+Example manifest:
+
+```json
+{
+  "domain": "volume_button_trigger",
+  "extension_point": "trigger",
+  "name": "Volume Buttons",
+  "description": "Listen for vol-up-up on a connected MIDI / HID device and emit a like intent.",
+  "codeowners": ["@you"],
+  "requirements": ["hid>=1.0"],
+  "documentation": "https://github.com/Osasuwu/like_spotify_mobile_app/blob/main/like_spotify/extensions/volume_button_trigger/README.md",
+  "stage": "experimental"
+}
+```
+
+`stage` is one of `experimental | stable | deprecated`. `requirements`
+is pip-compatible — the install bootstrap (see `install.ps1` / `install.sh`)
+resolves them at first enable.
+
+### 1. `Trigger` — emit a like intent
+
+```python
+# like_spotify/core/trigger.py (already shipped)
+class Trigger(ABC):
+    @abstractmethod
+    async def start(self, emit: EmitFn) -> None: ...
+    @abstractmethod
+    async def stop(self) -> None: ...
+```
+
+`start(emit)` is called once. Long-lived triggers register a listener
+(global hotkey, system-tray menu item, MQTT subscription, MIDI HID
+read loop) and call `emit()` each time the user signals "like the
+playing track". One-shot triggers (`OneShotCliTrigger`) `await emit()`
+inside `start` and return. `stop()` must be idempotent.
+
+Existing impls:
+
+- `tray_hotkey_trigger` — global keyboard hotkey (Windows).
+- `one_shot_cli_trigger` — per-invocation, any OS.
+
+**Skeleton for a third trigger (good-first-PR — `VolumeButtonTrigger`):**
+
+```python
+# like_spotify/extensions/volume_button_trigger/__init__.py
+"""VolumeButtonTrigger — emit a like intent on a vol-up-up double-tap.
+
+Watches an HID device for media-volume-up events. Two presses inside
+DOUBLE_TAP_WINDOW_MS count as a like signal — single presses still
+adjust system volume normally because we don't suppress them.
+
+Status: skeleton only — the HID device discovery + event-loop are
+TODOs. Pick this up by:
+
+  1. Decide your HID library (hidapi via `pip install hid`, or evdev on
+     Linux). Document it in `manifest.json::requirements`.
+  2. Implement `_listen` as an asyncio task that reads HID events and
+     calls `self._on_volume_up` on each press.
+  3. Match the "two presses in N ms" pattern (mirror the Android
+     `MediaEventPatternDetector.kt` logic — same domain shape, just
+     translated to Python).
+  4. Tests: feed synthetic timestamps to `_on_volume_up` and assert
+     `emit` is called exactly once per matched double-tap, never on
+     a single press, never on three presses spaced > window.
+
+Acceptance: vol-up-up likes the playing track; single vol-up still
+changes system volume. No state shared with TrayHotkeyTrigger.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from like_spotify.core.trigger import EmitFn, Trigger
+
+DOUBLE_TAP_WINDOW_MS = 400
+
+
+class VolumeButtonTrigger(Trigger):
+    def __init__(self, double_tap_window_ms: int = DOUBLE_TAP_WINDOW_MS) -> None:
+        self._window_ms = double_tap_window_ms
+        self._last_press_ms: float | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._emit: EmitFn | None = None
+        self._task: asyncio.Task | None = None
+
+    async def start(self, emit: EmitFn) -> None:
+        self._loop = asyncio.get_running_loop()
+        self._emit = emit
+        # TODO: open the HID device here and spawn a listener task that
+        # calls `self._on_volume_up()` on each press event.
+        self._task = self._loop.create_task(self._listen())
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+        # TODO: close the HID device here.
+
+    async def _listen(self) -> None:
+        # TODO: replace with a real `await device.read()` loop.
+        raise NotImplementedError("VolumeButtonTrigger HID listener — see TODOs")
+
+    def _on_volume_up(self, now_ms: float | None = None) -> None:
+        now_ms = now_ms if now_ms is not None else time.monotonic() * 1000
+        if (
+            self._last_press_ms is not None
+            and (now_ms - self._last_press_ms) <= self._window_ms
+        ):
+            # Double-tap matched — emit and reset so a third press doesn't
+            # also fire.
+            self._last_press_ms = None
+            if self._loop is not None and self._emit is not None:
+                asyncio.run_coroutine_threadsafe(self._emit(), self._loop)
+            return
+        self._last_press_ms = now_ms
+
+
+def TRIGGER(**_cfg) -> VolumeButtonTrigger:
+    return VolumeButtonTrigger()
+```
+
+### 2. `MusicProvider` — read playback + write a like
+
+```python
+# like_spotify/core/music_provider.py
+class MusicProvider(ABC):
+    @abstractmethod
+    async def get_currently_playing(self) -> CurrentTrack | None: ...
+    @abstractmethod
+    async def like(self, track: CurrentTrack) -> None: ...
+    @abstractmethod
+    async def is_liked(self, track: CurrentTrack) -> bool: ...
+    @abstractmethod
+    async def user_id(self) -> str: ...
+```
+
+Most second providers won't ship in Phase 1 (Spotify owns the world for
+this app), but the seam is wide enough to wrap YouTube Music, Tidal,
+or local Mopidy. Adding one is the second-implementation moment for
+this interface — refactoring around it is welcomed.
+
+OAuth flows belong inside the extension. See `extensions/spotify/`
+for a PKCE example (~70 LOC) and `like_spotify/auth/google.py` for an
+installed-app OAuth pattern with refresh.
+
+### 3. `Storage` — count likes across devices
+
+```python
+# like_spotify/core/storage.py
+class Storage(ABC):
+    @abstractmethod
+    async def increment(
+        self, user_id: str, track: CurrentTrack, was_already_liked: bool = False
+    ) -> int: ...
+    @abstractmethod
+    async def get_count(self, user_id: str, track: CurrentTrack) -> int: ...
+    @abstractmethod
+    async def record_artist_track(
+        self, user_id: str, artist_id: str, track_id: str
+    ) -> int: ...
+```
+
+`increment` is the hot path; it must be safe to call concurrently from
+multiple devices and return the new count. `was_already_liked` is the
+backfill flag — on first encounter with `True`, seed `count=2` and a
+`backfilled=TRUE` marker, otherwise `count=1`. See
+[#24](https://github.com/Osasuwu/like_spotify_mobile_app/issues/24)
+for why this exists.
+
+**Existing impls** (≥2, so the abstraction is real):
+
+- `supabase_storage` — Postgres RPC (`increment_track_like`).
+- `google_sheets_storage` — REST PUT/APPEND on a sheet.
+
+**Wanted next** (good-first-PR): `sqlite_storage` for users who don't
+want a cloud backend. The shared contract test in
+`tests/test_storage_contract.py` is parametrised over
+`(SupabaseStorage | GoogleSheetsStorage)` already — drop a SQLite
+fixture in there and you get all seven invariants for free.
+
+### 4. `PreLikeAction` — veto a like before it happens
+
+```python
+# like_spotify/core/actions.py
+class PreLikeAction(ABC):
+    @abstractmethod
+    async def run(self, ctx: LikeContext) -> bool: ...
+```
+
+Returning `False` aborts the like (feedback shows "Skipped by
+`<ActionName>`"). Pre-actions are independent: a raising pre-action is
+logged and skipped, later pre-actions still run, the like still
+proceeds. **Independence is the contract** — if you need a hard veto
+that survives a raise, raise from inside `run` and the host will catch
+it; but plan around that as the rare case.
+
+No `PreLikeAction` ships in default flavor yet — first impl is the
+obvious good-first-PR. Examples: "skip likes on tracks shorter than
+30s", "skip on the first 10s of a track (probably a misclick)".
+
+### 5. `PostLikeAction` — react to a successful like
+
+```python
+class PostLikeAction(ABC):
+    @abstractmethod
+    async def run(self, ctx: LikeContext) -> None: ...
+```
+
+Each action runs independently; a raise is logged and the chain
+continues (mirrors the Pre-action rule). The `ctx.like_count` field
+is populated by Storage *before* the post-chain runs — that's how
+`PromoteToBestOfAction` gates on "liked 3+ times".
+
+Existing impls: `archive_remove`, `promote_to_best_of`, `follow_artist`.
+
+**Provider-aware actions** downcast: if your action needs a
+Spotify-only API (e.g. playlist manipulation), check
+`isinstance(ctx.music_provider, SpotifyMusicProvider)` and use its
+provider-specific methods. Ship the action in a folder coupled to the
+provider's name, so the soft dependency is visible.
+
+## Adding an extension — checklist
+
+1. Create `like_spotify/extensions/<your_domain>/__init__.py` with the
+   concrete class and the matching top-level factory name (`TRIGGER`,
+   `MUSIC_PROVIDER`, `STORAGE`, `PRE_LIKE_ACTION`, or
+   `POST_LIKE_ACTION`).
+2. Create `manifest.json` next to it. The required keys are
+   `domain`, `extension_point`, `name`, `description`,
+   `codeowners`, `requirements`, and `stage`.
+3. Register the manifest in `pyproject.toml`'s
+   `[tool.setuptools.package-data]` block so it ships in the wheel.
+4. If the extension needs configuration, prompt for it in
+   `like_spotify/hosts/_common.py::do_setup` (the wizard) and read it
+   from `cfg` in the relevant `_build_*` helper.
+5. Tests under `tests/`. For `Storage`, drop your fixture into the
+   parametrised contract suite (`tests/test_storage_contract.py`). For
+   everything else, small async unit tests against the interface +
+   one slice in `tests/test_pipeline.py` if the host wiring is novel.
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Like Spotify
 
-Like the currently playing Spotify track with a headset button pattern (Android) or keyboard shortcut (desktop). Manages a Discover Weekly archive playlist — liked tracks are removed so you never re-listen to them.
+**One-button Spotify automation across your phone and laptop.** Like the currently-playing track with a headset pause-play pattern (Android) or a global keyboard hotkey (Windows tray; macOS / Linux CLI). On top of "like", a small rule engine runs per like: remove from an archive playlist (Discover Weekly clean-up), promote a track to a "best-of" playlist when you've liked it N times across devices, auto-follow an artist after N liked tracks. Counters live in Supabase or Google Sheets so phone + laptop see the same numbers.
+
+The desktop side is a **pluggable framework**, not a single tool. Five extension points — `Trigger`, `MusicProvider`, `Storage`, `PreLikeAction`, `PostLikeAction` — discover at startup via a filesystem convention (each extension is a folder with a `manifest.json` and a `TRIGGER` / `MUSIC_PROVIDER` / `STORAGE` / `PRE_LIKE_ACTION` / `POST_LIKE_ACTION` factory). Drop a folder, restart, your code runs in the like pipeline. See [CONTRIBUTING.md](CONTRIBUTING.md) for the plugin-author guide.
+
+Keywords for the search-engine crowd: spotify like hotkey, spotify automation, headset pause-play like, spotify scrobbler alternative, spotify plugin framework, cross-device like counter.
 
 ## How it works
 
@@ -9,6 +13,18 @@ Like the currently playing Spotify track with a headset button pattern (Android)
 3. **Archive cleanup** — if the track is in your archive playlist, it gets removed
 4. **Best-of promotion** — like a track 3 times across devices and it's added to your best-of playlist
 5. **Artist follow** — like 5+ tracks from an artist and they get auto-followed
+
+## How it compares
+
+There are several adjacent projects in this space; they solve overlapping problems but none solve all four of *one-press cross-device like + rule engine + headset-button trigger on phone + plugin framework on desktop*.
+
+| Project | One-press like | Headset trigger (phone) | Hotkey trigger (desktop) | Rule engine (archive/best-of/follow) | Cross-device counters | Pluggable | Use **theirs** when |
+|---|---|---|---|---|---|---|---|
+| **Like Spotify** (this) | ✓ | ✓ Android | ✓ Windows tray + mac/linux CLI | ✓ | ✓ Supabase / Sheets | ✓ 5 typed seams + manifest discovery | n/a |
+| [Pano Scrobbler](https://github.com/kawaiiDango/pano-scrobbler) | partial (love via UI) | — (notification scrape) | — | — (scrobble target only) | — | provider seam only (write target) | you want **scrobbling history** to last.fm/listenbrainz/librefm/pleroma. Pano is the right answer for "where did my listens go" — we don't try to replace it. |
+| [SpotifyHotKeys.ahk](https://github.com/rjmccallumbigl/SpotifyHotKeys.ahk) | ✓ (like / unlike) | — | ✓ Windows only (AutoHotKey) | — | — | — | you already live in AutoHotKey and want a small single-file script you can paste & edit. We're heavier (Python install) but cross-platform and rule-capable. |
+| [Music Assistant](https://www.music-assistant.io/) | partial (per-provider) | — | via Home Assistant | extensive (queue / library / sync) | — (per-instance) | ✓ ~60 providers | you want **Home Assistant-grade music orchestration** — multi-provider library merging, multi-room sync, queue scripting. We don't try to be your music server; we sit next to your existing Spotify client. |
+| [n8n](https://n8n.io/) / Zapier / IFTTT | only via polling | — | — | yes (general workflows) | yes (workflow vars) | ✓ generic | you want **a generic workflow engine** with a UI and 400+ integrations. We're the inverse — narrow to "like + post-like rules", but one button press and ~30 ms latency vs minutes of polling. |
 
 ## Quick start
 

--- a/like_spotify/extensions/volume_button_trigger/__init__.py
+++ b/like_spotify/extensions/volume_button_trigger/__init__.py
@@ -1,0 +1,93 @@
+"""VolumeButtonTrigger — skeleton.
+
+Emit a like intent on a vol-up-up double-tap on a connected HID
+device. Watches an HID volume-up event stream; two presses inside
+`DOUBLE_TAP_WINDOW_MS` count as a like signal. Single presses still
+adjust system volume normally — we don't suppress them.
+
+**Status: skeleton.** The HID discovery + read loop are TODOs.
+See CONTRIBUTING.md → "Skeleton for a third trigger" for the
+end-to-end pick-up checklist. Manifest stage is `experimental`.
+
+Pattern-matching shape mirrors the Android
+`MediaEventPatternDetector.kt` — same domain, different language.
+
+Slice: #29 (skeleton drop, no impl).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from like_spotify.core.trigger import EmitFn, Trigger
+
+DOUBLE_TAP_WINDOW_MS = 400
+
+
+class VolumeButtonTrigger(Trigger):
+    """Match two vol-up presses inside `double_tap_window_ms` → emit.
+
+    The double-tap matcher is fully implemented and unit-testable in
+    isolation — it's just a stamp comparator. The missing piece is
+    `_listen`, which must read an HID device and call
+    `_on_volume_up()` per event.
+    """
+
+    def __init__(self, double_tap_window_ms: int = DOUBLE_TAP_WINDOW_MS) -> None:
+        self._window_ms = double_tap_window_ms
+        self._last_press_ms: float | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._emit: EmitFn | None = None
+        self._task: asyncio.Task | None = None
+
+    async def start(self, emit: EmitFn) -> None:
+        self._loop = asyncio.get_running_loop()
+        self._emit = emit
+        self._task = self._loop.create_task(self._listen())
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._task = None
+        # TODO: close the HID device handle here.
+
+    async def _listen(self) -> None:
+        """HID read loop. TODO — see module docstring.
+
+        Pick this up by:
+
+          1. Decide your HID library (hidapi via `pip install hid`,
+             or evdev on Linux). Add it to manifest.requirements.
+          2. Open the volume-keys device (you'll need to enumerate
+             and filter; on Windows it's a HID consumer-control
+             device, on Linux it's an evdev `KEY_VOLUMEUP` keysym).
+          3. On each volume-up event, call `self._on_volume_up()`.
+             Do NOT suppress the event — single presses still adjust
+             system volume.
+        """
+        raise NotImplementedError(
+            "VolumeButtonTrigger HID listener — see CONTRIBUTING.md"
+        )
+
+    def _on_volume_up(self, now_ms: float | None = None) -> None:
+        """Pure pattern matcher. Side-effect-free except for emit."""
+        now_ms = now_ms if now_ms is not None else time.monotonic() * 1000
+        if (
+            self._last_press_ms is not None
+            and (now_ms - self._last_press_ms) <= self._window_ms
+        ):
+            # Double-tap matched — reset so a third press doesn't also fire.
+            self._last_press_ms = None
+            if self._loop is not None and self._emit is not None:
+                asyncio.run_coroutine_threadsafe(self._emit(), self._loop)
+            return
+        self._last_press_ms = now_ms
+
+
+def TRIGGER(double_tap_window_ms: int = DOUBLE_TAP_WINDOW_MS) -> VolumeButtonTrigger:
+    return VolumeButtonTrigger(double_tap_window_ms=double_tap_window_ms)

--- a/like_spotify/extensions/volume_button_trigger/manifest.json
+++ b/like_spotify/extensions/volume_button_trigger/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "volume_button_trigger",
+  "extension_point": "trigger",
+  "name": "Volume Buttons (HID double-tap)",
+  "description": "Skeleton: vol-up-up on a connected HID device emits a like intent. HID read loop is a TODO — see CONTRIBUTING.md.",
+  "codeowners": ["@Osasuwu"],
+  "requirements": [],
+  "documentation": "https://github.com/Osasuwu/like_spotify_mobile_app/blob/main/CONTRIBUTING.md",
+  "stage": "experimental"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ exclude = ["tests*", ".venv-build*"]
 "like_spotify.extensions.spotify" = ["manifest.json"]
 "like_spotify.extensions.supabase_storage" = ["manifest.json"]
 "like_spotify.extensions.tray_hotkey_trigger" = ["manifest.json"]
+"like_spotify.extensions.volume_button_trigger" = ["manifest.json"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_volume_button_trigger.py
+++ b/tests/test_volume_button_trigger.py
@@ -1,0 +1,112 @@
+"""Smoke tests for the VolumeButtonTrigger skeleton's pure pattern matcher.
+
+The HID read loop is intentionally a NotImplementedError stub (issue
+#29 ships the skeleton; implementation is a separate good-first-PR per
+CONTRIBUTING.md). We don't test `_listen`. We DO test:
+
+1. The double-tap window matcher is correct in isolation. Future
+   implementers shouldn't break the matcher when adding the HID loop.
+2. The factory returns a Trigger instance the host can wire.
+
+The "two presses inside window → emit" path needs an event loop
+because the trigger schedules via `run_coroutine_threadsafe`. We
+exercise it via a tiny harness.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from like_spotify.core.trigger import Trigger
+from like_spotify.extensions.volume_button_trigger import (
+    TRIGGER,
+    DOUBLE_TAP_WINDOW_MS,
+    VolumeButtonTrigger,
+)
+
+
+def test_factory_returns_trigger_instance() -> None:
+    assert isinstance(TRIGGER(), Trigger)
+    assert isinstance(TRIGGER(), VolumeButtonTrigger)
+
+
+def test_factory_propagates_window_override() -> None:
+    trigger = TRIGGER(double_tap_window_ms=123)
+    assert trigger._window_ms == 123
+
+
+def test_single_press_does_not_emit() -> None:
+    trigger = VolumeButtonTrigger(double_tap_window_ms=300)
+    # No loop wired — emit path is dormant. _on_volume_up should just
+    # store the timestamp and return.
+    trigger._on_volume_up(now_ms=0)
+    assert trigger._last_press_ms == 0
+
+
+def test_two_presses_inside_window_match() -> None:
+    """The matcher consumes the first stamp on a match — a third press
+    must NOT count as a second double-tap with the matched event."""
+    trigger = VolumeButtonTrigger(double_tap_window_ms=300)
+    trigger._on_volume_up(now_ms=0)
+    trigger._on_volume_up(now_ms=100)  # inside the window → match
+    assert trigger._last_press_ms is None  # consumed
+
+
+def test_two_presses_outside_window_do_not_match() -> None:
+    trigger = VolumeButtonTrigger(double_tap_window_ms=300)
+    trigger._on_volume_up(now_ms=0)
+    trigger._on_volume_up(now_ms=1000)
+    # The second press becomes the new candidate — not a match.
+    assert trigger._last_press_ms == 1000
+
+
+def test_three_presses_spaced_widely_do_not_match() -> None:
+    """Three single presses each > window apart must never emit."""
+    trigger = VolumeButtonTrigger(double_tap_window_ms=200)
+    trigger._on_volume_up(now_ms=0)
+    trigger._on_volume_up(now_ms=500)
+    trigger._on_volume_up(now_ms=1000)
+    # Last single press is the candidate; no match was ever consumed.
+    assert trigger._last_press_ms == 1000
+
+
+@pytest.mark.asyncio
+async def test_double_tap_schedules_emit_on_running_loop() -> None:
+    """End-to-end: when the trigger has a loop + emit wired (as the host
+    arranges in `start`), a matched double-tap fires `emit` exactly once.
+    """
+    trigger = VolumeButtonTrigger(double_tap_window_ms=300)
+    calls = 0
+
+    async def emit() -> None:
+        nonlocal calls
+        calls += 1
+
+    # Manually wire what `start` would wire — we don't run `_listen`.
+    trigger._loop = asyncio.get_running_loop()
+    trigger._emit = emit
+
+    trigger._on_volume_up(now_ms=0)
+    trigger._on_volume_up(now_ms=50)  # match
+
+    # `run_coroutine_threadsafe` returns a `concurrent.futures.Future`
+    # that completes once the coroutine has been scheduled and awaited.
+    # Yielding once lets the scheduled coroutine run.
+    await asyncio.sleep(0.05)
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_listen_is_not_implemented_yet() -> None:
+    """Guard rail: the skeleton must NOT silently pretend to listen.
+    A future implementer replacing this with a real HID loop will
+    delete this test as part of their PR."""
+    trigger = VolumeButtonTrigger()
+    with pytest.raises(NotImplementedError):
+        await trigger._listen()
+
+
+def test_module_window_constant_matches_class_default() -> None:
+    assert VolumeButtonTrigger()._window_ms == DOUBLE_TAP_WINDOW_MS


### PR DESCRIPTION
## Summary

- **Repo metadata** (set via \`gh\`, not in the diff): description + homepage + 12 topics (\`spotify\`, \`spotify-automation\`, \`hotkey\`, \`media-keys\`, \`headset\`, \`like-track\`, \`scrobbler-alternative\`, \`plugin-framework\`, \`music-automation\`, \`cross-device\`, \`flutter\`, \`python\`).
- **README**: keyword-rich opener + plugin-framework callout + comparison table vs Pano Scrobbler / SpotifyHotKeys.ahk / Music Assistant / n8n.
- **CONTRIBUTING.md**: plugin-author guide for each of the 5 extension points, with contract notes, existing impls, and "what's wanted next". Registration mechanism documented inline. \`VolumeButtonTrigger\` skeleton example with full TODO checklist.
- **VolumeButtonTrigger skeleton** (\`like_spotify/extensions/volume_button_trigger/\`): pure double-tap matcher implemented + tested; HID read loop is a \`NotImplementedError\` stub flagged as good-first-PR. Manifest stage = \`experimental\`.
- **.gitignore hygiene**: \`**/dist/\`, \`**/build/\`, \`.venv*/\`, \`.coverage\`.

## Acceptance criteria

- [x] \`gh repo view\` shows the new description and topics (verified via \`gh repo view --json description,homepageUrl\` + \`gh api repos/.../topics\`).
- [x] Comparison table positions us vs all four adjacent projects (use ours when / use theirs when).
- [x] CONTRIBUTING.md gets a contributor through "I want a custom Trigger" without reading core source — the Trigger section quotes the ABC, lists existing impls, and ships a working skeleton with the matcher already implemented + tested.
- [x] \`.gitignore\` covers PyInstaller artifacts that currently leak as untracked (\`**/dist/\`, \`**/build/\`, plus \`.venv-*/\` for local dev venvs).
- [ ] Searching prior-art queries (\`spotify like hotkey framework\`, \`spotify automation plugin\`, \`headset like spotify track\`) returns this repo on the first page within ~1 week of indexing — that's a wait-and-see check; the topics + description are seeded.

## Test plan

- [x] \`pytest\` — 132 pass (123 baseline + 9 \`test_volume_button_trigger\`).
- [x] Manifest loads cleanly: \`python -c \"from like_spotify.extensions.volume_button_trigger import TRIGGER; t = TRIGGER(); print(type(t).__name__)\"\` → \`VolumeButtonTrigger\`.
- [x] \`_listen\` raises \`NotImplementedError\` (guard test) so future implementers will see the stub instead of silent no-op.

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)