### PR TITLE
feat(desktop): remove-without-like hotkey + reliable per-action audio (closes #43)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -332,6 +332,18 @@ is populated by Storage *before* the post-chain runs — that's how
 
 Existing impls: `archive_remove`, `promote_to_best_of`, `follow_artist`.
 
+`archive_remove` reads its target playlist from
+`actions.archive_remove.playlist_name` in `config.json`; a blank name
+disables it (and `build_post_actions` drops the action). The same name
+feeds the standalone **remove-without-like** flow: `RemoveFromPlaylistPipeline`
+(in `core/pipeline.py`) removes the currently-playing track from that
+playlist *without* a like. The Windows tray host binds it to a second
+global hotkey, `trigger.remove_hotkey` (default `Ctrl+Shift+Alt+Q`), and
+every host exposes it as `like-spotify remove-once`. The hotkey is
+skipped if it equals `trigger.hotkey` or no archive name is configured.
+`resolve_archive_playlist_name` in `hosts/_common.py` is the single
+source of truth both flows read.
+
 **Provider-aware actions** downcast: if your action needs a
 Spotify-only API (e.g. playlist manipulation), check
 `isinstance(ctx.music_provider, SpotifyMusicProvider)` and use its

--- a/README.md
+++ b/README.md
@@ -100,8 +100,17 @@ The wizard is re-runnable; existing tokens are kept unless you pass
 ```bash
 like-spotify            # Windows: tray host with the hotkey (default Ctrl+Shift+Alt+W)
 like-spotify like-once  # any OS: like the currently-playing track and exit
+like-spotify remove-once # any OS: remove the current track from the archive playlist (no like)
 like-spotify --config   # print config + token paths
 ```
+
+On Windows the tray host also binds a **second** global hotkey (default
+`Ctrl+Shift+Alt+Q`) that removes the currently-playing track from your
+Discover-Weekly archive playlist **without liking it** — for tracks you
+want gone but not in your Liked Songs. It's active only once you set an
+archive playlist name in `--setup`; if it collides with the like hotkey
+it's skipped. Audio feedback is audible through the default sound device
+and distinct per action (like / remove / error).
 
 **Single-file `.exe`** (for users without Python): build via
 `tools\build.bat` → `dist\LikeSpotify.exe`.
@@ -183,11 +192,13 @@ Android (Flutter + Kotlin)          Desktop (Python framework)
 | Setting | Android | Desktop |
 |---------|---------|---------|
 | Trigger pattern / hotkey | In-app UI | `~/.like_spotify/config.json` → `trigger.hotkey` (default `Ctrl+Shift+Alt+W`) |
+| Remove-from-archive hotkey | n/a (one trigger on headphones) | `~/.like_spotify/config.json` → `trigger.remove_hotkey` (default `Ctrl+Shift+Alt+Q`) |
+| Archive playlist name | In-app UI | `~/.like_spotify/config.json` → `actions.archive_remove.playlist_name` (blank = archive-remove disabled) |
 | Spotify client_id | `.env` (`SPOTIFY_CLIENT_ID`) | `like-spotify --setup` → `~/.like_spotify/config.json` |
 | Spotify tokens | `FlutterSecureStorage` | `~/.like_spotify/spotify_token.json` |
 | Storage backend | (Supabase only) | `~/.like_spotify/config.json` → `storage.backend` (`supabase` / `sheets` / `none`) |
 | Google Sheets tokens | n/a | `~/.like_spotify/google_token.json` (refreshed automatically) |
-| Archive / best-of / follow | In-app UI | `~/.like_spotify/config.json` → `actions.{archive_remove,promote_to_best_of,follow_artist}` |
+| Best-of / follow | In-app UI | `~/.like_spotify/config.json` → `actions.{promote_to_best_of,follow_artist}` |
 
 ## License
 

--- a/like_spotify/core/pipeline.py
+++ b/like_spotify/core/pipeline.py
@@ -1,16 +1,24 @@
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
+from typing import Protocol
 
 from .actions import PostLikeAction, PreLikeAction
 from .music_provider import MusicProvider
 from .storage import Storage
 from .types import CurrentTrack, LikeContext
 
-# (success, title, message) plus an optional keyword `kind` that hosts use
-# to pick a distinct confirmation sound — "like" (default), "remove", or
-# whatever a future flow needs. Callers that don't care omit it; feedback
-# impls default it to "like", so the 3-arg call stays valid everywhere.
-FeedbackFn = Callable[..., None]
+
+class FeedbackFn(Protocol):
+    """(success, title, message) plus an optional keyword `kind` that hosts
+    use to pick a distinct confirmation sound — "like" (default), "remove",
+    or whatever a future flow needs. Callers that don't care omit `kind`;
+    feedback impls default it to "like", so the 3-arg call stays valid
+    everywhere. A Protocol (not `Callable[..., None]`) so mypy/pyright still
+    catch mismatched argument types at the call site."""
+
+    def __call__(
+        self, success: bool, title: str, message: str, *, kind: str = "like"
+    ) -> None: ...
 
 logger = logging.getLogger(__name__)
 
@@ -138,9 +146,10 @@ class RemoveFromPlaylistPipeline:
     extension import.
 
     The resolved playlist id is cached after the first successful lookup.
-    A miss (playlist not found, or a lookup error) is *not* cached, so a
-    later press re-resolves — useful in a long-lived tray when the user
-    creates the playlist after launch.
+    A miss (playlist not found, or a lookup error) is *not* cached, and a
+    cached id is dropped again if the remove call later fails (the playlist
+    may have been deleted/renamed) — so a later press re-resolves. Useful in
+    a long-lived tray when the user creates the playlist after launch.
 
     Slice: #43 (remove-without-like hotkey).
     """
@@ -201,6 +210,10 @@ class RemoveFromPlaylistPipeline:
         try:
             await remover(track.provider_track_id, self._playlist_id)
         except Exception as e:
+            # The cached id may be stale (playlist deleted/renamed since the
+            # last resolve) — drop it so the next press re-resolves instead
+            # of failing forever against a dead id.
+            self._playlist_id = None
             self._feedback(False, "Remove failed", str(e), kind="remove")
             return
 

--- a/like_spotify/core/pipeline.py
+++ b/like_spotify/core/pipeline.py
@@ -6,7 +6,11 @@ from .music_provider import MusicProvider
 from .storage import Storage
 from .types import CurrentTrack, LikeContext
 
-FeedbackFn = Callable[[bool, str, str], None]
+# (success, title, message) plus an optional keyword `kind` that hosts use
+# to pick a distinct confirmation sound — "like" (default), "remove", or
+# whatever a future flow needs. Callers that don't care omit it; feedback
+# impls default it to "like", so the 3-arg call stays valid everywhere.
+FeedbackFn = Callable[..., None]
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +119,97 @@ class Pipeline:
 
         title = "Liked" if ctx.like_count is None else f"Liked × {ctx.like_count}"
         self._feedback(True, title, _display(ctx.track))
+
+
+class RemoveFromPlaylistPipeline:
+    """Remove the currently-playing track from a named playlist — no like.
+
+    Powers the "I don't want this in my Discover Weekly archive" hotkey.
+    The like flow's `ArchiveRemoveAction` only fires *after* a like, so it
+    can't help with tracks the user dislikes; this is the second intent —
+    a separate Trigger wired here lets the user curate a playlist without
+    liking the track.
+
+    Provider-agnostic by duck typing: it needs `get_currently_playing`
+    (on the `MusicProvider` base) plus `find_playlist_by_name` /
+    `remove_track_from_playlist` (Spotify-flavored extras, not on the
+    base). A provider lacking the playlist API gets a clean error
+    feedback rather than an exception — keeping `core` free of any
+    extension import.
+
+    The resolved playlist id is cached after the first successful lookup.
+    A miss (playlist not found, or a lookup error) is *not* cached, so a
+    later press re-resolves — useful in a long-lived tray when the user
+    creates the playlist after launch.
+
+    Slice: #43 (remove-without-like hotkey).
+    """
+
+    def __init__(
+        self,
+        provider: MusicProvider,
+        feedback: FeedbackFn,
+        playlist_name: str,
+    ) -> None:
+        normalized = (playlist_name or "").strip()
+        if not normalized:
+            raise ValueError("remove playlist_name is required (non-empty)")
+        self._provider = provider
+        self._feedback = feedback
+        self._playlist_name = normalized
+        self._playlist_id: str | None = None
+
+    async def run_once(self) -> None:
+        try:
+            track = await self._provider.get_currently_playing()
+        except Exception as e:
+            self._feedback(
+                False, "Error", f"Could not read playback: {e}", kind="remove"
+            )
+            return
+
+        if track is None:
+            self._feedback(False, "Nothing playing", "", kind="remove")
+            return
+
+        finder = getattr(self._provider, "find_playlist_by_name", None)
+        remover = getattr(self._provider, "remove_track_from_playlist", None)
+        if finder is None or remover is None:
+            self._feedback(
+                False,
+                "Remove unsupported",
+                "provider has no playlist API",
+                kind="remove",
+            )
+            return
+
+        if self._playlist_id is None:
+            try:
+                self._playlist_id = await finder(self._playlist_name)
+            except Exception as e:
+                # Not cached — next press retries.
+                self._feedback(
+                    False, "Playlist lookup failed", str(e), kind="remove"
+                )
+                return
+            if not self._playlist_id:
+                self._feedback(
+                    False, "Playlist not found", self._playlist_name, kind="remove"
+                )
+                return
+
+        try:
+            await remover(track.provider_track_id, self._playlist_id)
+        except Exception as e:
+            self._feedback(False, "Remove failed", str(e), kind="remove")
+            return
+
+        self._feedback(
+            True,
+            f"Removed from {self._playlist_name}",
+            _display(track),
+            kind="remove",
+        )
 
 
 def _display(track: CurrentTrack) -> str:

--- a/like_spotify/hosts/_common.py
+++ b/like_spotify/hosts/_common.py
@@ -16,6 +16,7 @@ Slice history:
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import os
 import sys
@@ -23,7 +24,11 @@ from pathlib import Path
 
 from like_spotify.auth import google as google_auth
 from like_spotify.core.actions import PostLikeAction
+from like_spotify.core.pipeline import FeedbackFn, RemoveFromPlaylistPipeline
 from like_spotify.core.storage import Storage
+from like_spotify.extensions.one_shot_cli_trigger import (
+    TRIGGER as make_one_shot_cli_trigger,
+)
 from like_spotify.extensions.archive_remove import (
     POST_LIKE_ACTION as make_archive_remove_action,
 )
@@ -39,6 +44,12 @@ from like_spotify.extensions.promote_to_best_of import (
 from like_spotify.extensions.spotify import MUSIC_PROVIDER as make_spotify_provider
 from like_spotify.extensions.supabase_storage import STORAGE as make_supabase_storage
 from like_spotify.extensions.tray_hotkey_trigger import DEFAULT_HOTKEY
+
+# Second hotkey: remove the current track from the archive playlist WITHOUT
+# liking it. Distinct from DEFAULT_HOTKEY (the like trigger). The desktop can
+# bind arbitrarily many triggers; headphones are limited to one media-button
+# pattern, so this is desktop-only by design.
+DEFAULT_REMOVE_HOTKEY = "ctrl+shift+alt+q"
 
 # ── Paths ──────────────────────────────────────────────────────────────
 
@@ -124,6 +135,30 @@ def build_storage(cfg: dict) -> Storage | None:
     return None
 
 
+def resolve_archive_playlist_name(cfg: dict) -> str:
+    """The configured Discover Weekly archive playlist name, or "".
+
+    Single source of truth for both the like-flow `ArchiveRemoveAction`
+    and the remove-without-like `RemoveFromPlaylistPipeline` — they curate
+    the *same* playlist, so they must read the same key. Honors the
+    `actions.archive_remove.enabled = false` opt-out (returns "" when off).
+    """
+    nested = cfg.get("actions") if isinstance(cfg.get("actions"), dict) else {}
+    archive_cfg = (
+        nested.get("archive_remove")
+        if isinstance(nested.get("archive_remove"), dict)
+        else {}
+    )
+    if not archive_cfg.get("enabled", True):
+        return ""
+    return (
+        archive_cfg.get("playlist_name")
+        or nested.get("archive_playlist_name")
+        or cfg.get("archive_playlist_name")  # legacy flat key
+        or ""
+    )
+
+
 def build_post_actions(
     cfg: dict, storage: Storage | None
 ) -> list[PostLikeAction]:
@@ -135,14 +170,8 @@ def build_post_actions(
     actions: list[PostLikeAction] = []
     nested = cfg.get("actions") if isinstance(cfg.get("actions"), dict) else {}
 
-    archive_cfg = nested.get("archive_remove") if isinstance(nested.get("archive_remove"), dict) else {}
-    archive_name = (
-        archive_cfg.get("playlist_name")
-        or nested.get("archive_playlist_name")
-        or cfg.get("archive_playlist_name")  # legacy flat key
-        or ""
-    )
-    if archive_name and archive_cfg.get("enabled", True):
+    archive_name = resolve_archive_playlist_name(cfg)
+    if archive_name:
         try:
             actions.append(make_archive_remove_action(playlist_name=archive_name))
         except Exception:
@@ -191,6 +220,58 @@ def resolve_client_id(cfg: dict) -> str:
 
 def make_provider(client_id: str):
     return make_spotify_provider(client_id=client_id, token_path=SPOTIFY_TOKEN_FILE)
+
+
+def resolve_remove_hotkey(cfg: dict) -> str:
+    return cfg.get("trigger", {}).get("remove_hotkey", DEFAULT_REMOVE_HOTKEY)
+
+
+def run_one_shot(pipeline, feedback) -> int:
+    """Drive a single pipeline pass via OneShotCliTrigger; return an exit code.
+
+    Shared by every host's `like-once` / `remove-once` subcommand: the
+    only thing that varies between them is which pipeline is built and how
+    config errors are surfaced (handled by the caller). Exit code follows
+    the pipeline's last feedback outcome — 0 on success, 1 on failure or
+    if nothing was emitted — so the command is scriptable.
+    """
+    trigger = make_one_shot_cli_trigger()
+
+    async def emit() -> None:
+        await pipeline.run_once()
+
+    async def run() -> None:
+        try:
+            await trigger.start(emit)
+        finally:
+            await trigger.stop()
+
+    asyncio.run(run())
+
+    if not getattr(feedback, "calls", None):
+        return 1
+    return 0 if feedback.calls[-1][0] else 1
+
+
+def build_remove_pipeline(
+    cfg: dict, provider, feedback: FeedbackFn
+) -> RemoveFromPlaylistPipeline | None:
+    """Build the remove-without-like pipeline, or None when not configured.
+
+    Wired only when an archive playlist name is set — without a target
+    playlist there's nothing to remove from, so the second hotkey stays
+    dark rather than failing on every press. Targets the same playlist as
+    the like-flow archive action (see `resolve_archive_playlist_name`).
+    """
+    archive_name = resolve_archive_playlist_name(cfg)
+    if not archive_name:
+        return None
+    try:
+        return RemoveFromPlaylistPipeline(
+            provider=provider, feedback=feedback, playlist_name=archive_name
+        )
+    except ValueError:
+        return None
 
 
 # ── Interactive setup ──────────────────────────────────────────────────
@@ -256,6 +337,7 @@ def do_setup(reauth: bool = False) -> int:
     try:
         _setup_spotify(cfg, reauth=reauth)
         _setup_storage(cfg, reauth=reauth)
+        _setup_archive(cfg)
         _setup_autostart()
     except _SetupAbort as e:
         print(f"Aborted: {e}", file=sys.stderr)
@@ -274,7 +356,7 @@ def do_setup(reauth: bool = False) -> int:
 
 
 def _setup_spotify(cfg: dict, *, reauth: bool) -> None:
-    print("\n[1/3] Spotify")
+    print("\n[1/4] Spotify")
     current_id = cfg.get("spotify", {}).get("client_id", "")
     client_id = _prompt_secret("  Client ID", current=current_id)
     if not client_id:
@@ -299,7 +381,7 @@ def _setup_spotify(cfg: dict, *, reauth: bool) -> None:
 
 
 def _setup_storage(cfg: dict, *, reauth: bool) -> None:
-    print("\n[2/3] Storage (counts likes across devices)")
+    print("\n[2/4] Storage (counts likes across devices)")
     current_backend = (cfg.get("storage", {}) or {}).get("backend", "")
     default = current_backend or "none"
     backend = _prompt_choice(
@@ -355,8 +437,58 @@ def _setup_storage(cfg: dict, *, reauth: bool) -> None:
         print("  ✓ Counter disabled — likes still work, no count tracking.")
 
 
+def _setup_archive(cfg: dict) -> None:
+    """Discover Weekly clean-up: archive playlist + remove-without-like hotkey.
+
+    Two coupled settings, one playlist:
+      - `actions.archive_remove.playlist_name` — when you like a track, it's
+        auto-removed from this "save-for-later" playlist (the like flow's
+        PostLikeAction).
+      - `trigger.remove_hotkey` — a second hotkey that removes the current
+        track from the *same* playlist WITHOUT liking it, for tracks you
+        want gone but not saved. Only meaningful when a playlist is set.
+
+    Empty input keeps the current value (the wizard's keep-on-blank idiom),
+    so re-running setup for an unrelated step won't clobber the archive.
+    Type `-` to turn the feature off; blank with nothing set = skip.
+    """
+    print("\n[3/4] Discover Weekly clean-up (optional)")
+    print(
+        "  Name a playlist (e.g. an archived copy of Discover Weekly) to "
+        "curate.\n"
+        "  Liking a track removes it from this playlist; a second hotkey "
+        "removes\n"
+        "  the current track WITHOUT liking it. Blank = skip, '-' = turn off."
+    )
+    current_name = resolve_archive_playlist_name(cfg)
+    if current_name:
+        print(f"  (currently: {current_name})")
+    playlist_name = _prompt("  Archive playlist name", default=current_name)
+    archive_cfg = cfg.setdefault("actions", {}).setdefault("archive_remove", {})
+
+    if playlist_name == "-" or not playlist_name:
+        # '-' disables an existing name; bare-blank with nothing set = skip.
+        if current_name:
+            archive_cfg["enabled"] = False
+            print("  ✓ Clean-up disabled.")
+        else:
+            print("  ✓ Skipped.")
+        return
+
+    archive_cfg["playlist_name"] = playlist_name
+    archive_cfg["enabled"] = True
+
+    current_hotkey = resolve_remove_hotkey(cfg)
+    remove_hotkey = _prompt(
+        "  Remove-without-like hotkey", default=current_hotkey or DEFAULT_REMOVE_HOTKEY
+    )
+    cfg.setdefault("trigger", {})["remove_hotkey"] = remove_hotkey
+    print(f"  ✓ Archive playlist: {playlist_name}")
+    print(f"  ✓ Remove hotkey: {remove_hotkey.upper()}")
+
+
 def _setup_autostart() -> None:
-    print("\n[3/3] Autostart")
+    print("\n[4/4] Autostart")
     if sys.platform != "win32":
         # Print instructions only — issue AC: no auto-config on mac/linux.
         if sys.platform == "darwin":
@@ -415,10 +547,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     """Parse the shared CLI surface.
 
     Subcommands:
-        (none)     — run the platform's default host (tray on Windows,
-                     CLI-only stub elsewhere).
-        like-once  — perform a single like and exit (uses OneShotCliTrigger,
-                     works on every platform).
+        (none)      — run the platform's default host (tray on Windows,
+                      CLI-only stub elsewhere).
+        like-once   — perform a single like and exit (uses OneShotCliTrigger,
+                      works on every platform).
+        remove-once — remove the currently-playing track from the archive
+                      playlist WITHOUT liking it, then exit.
 
     Flags (back-compat with the original tray launcher):
         --setup    — interactive Client ID + browser OAuth.
@@ -429,10 +563,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "command",
         nargs="?",
         default="run",
-        choices=["run", "like-once"],
+        choices=["run", "like-once", "remove-once"],
         help=(
             "run (default) — start the long-lived host (tray on Windows). "
-            "like-once — perform a single like and exit."
+            "like-once — perform a single like and exit. "
+            "remove-once — remove the current track from the archive "
+            "playlist without liking it."
         ),
     )
     p.add_argument("--setup", action="store_true", help="Interactive setup wizard.")

--- a/like_spotify/hosts/_common.py
+++ b/like_spotify/hosts/_common.py
@@ -466,13 +466,17 @@ def _setup_archive(cfg: dict) -> None:
     playlist_name = _prompt("  Archive playlist name", default=current_name)
     archive_cfg = cfg.setdefault("actions", {}).setdefault("archive_remove", {})
 
-    if playlist_name == "-" or not playlist_name:
-        # '-' disables an existing name; bare-blank with nothing set = skip.
-        if current_name:
-            archive_cfg["enabled"] = False
-            print("  ✓ Clean-up disabled.")
-        else:
-            print("  ✓ Skipped.")
+    if playlist_name == "-":
+        # Explicit off switch — idempotent: works whether or not a name was
+        # set. The message reflects which it was so '-' never looks like a
+        # no-op when the user clearly asked to turn it off.
+        archive_cfg["enabled"] = False
+        print("  ✓ Clean-up disabled." if current_name else "  ✓ Already disabled.")
+        return
+    if not playlist_name:
+        # Bare Enter is only empty when nothing was configured (keep-on-blank
+        # would otherwise have returned current_name) — so this is a skip.
+        print("  ✓ Skipped.")
         return
 
     archive_cfg["playlist_name"] = playlist_name

--- a/like_spotify/hosts/_stub.py
+++ b/like_spotify/hosts/_stub.py
@@ -17,13 +17,9 @@ Slice: #27.
 
 from __future__ import annotations
 
-import asyncio
 import sys
 
 from like_spotify.core.pipeline import Pipeline
-from like_spotify.extensions.one_shot_cli_trigger import (
-    TRIGGER as make_one_shot_cli_trigger,
-)
 
 from . import _common
 
@@ -48,13 +44,22 @@ def _no_tray_message() -> str:
 
 
 class CliFeedback:
-    """Plain-stdout feedback for the CLI host."""
+    """Plain-stdout feedback for the CLI host.
+
+    Accepts the optional `kind` keyword (e.g. "remove") so the
+    remove-without-like pipeline can call it; the CLI has no audio, so
+    `kind` only affects nothing here — it's stored for tests / parity.
+    """
 
     def __init__(self) -> None:
         self.calls: list[tuple[bool, str, str]] = []
+        self.kinds: list[str] = []
 
-    def __call__(self, success: bool, title: str, message: str) -> None:
+    def __call__(
+        self, success: bool, title: str, message: str, *, kind: str = "like"
+    ) -> None:
         self.calls.append((success, title, message))
+        self.kinds.append(kind)
         stream = sys.stdout if success else sys.stderr
         prefix = "[ok]" if success else "[err]"
         line = f"{prefix} {title}"
@@ -63,7 +68,8 @@ class CliFeedback:
         print(line, file=stream)
 
 
-def _run_like_once() -> int:
+def _resolved_provider_or_hint():
+    """(provider, None, cfg) when ready, else (None, exit_code, cfg)."""
     cfg = _common.load_config()
     client_id = _common.resolve_client_id(cfg)
     if not client_id:
@@ -71,7 +77,7 @@ def _run_like_once() -> int:
             "Not configured. Run:\n\n    like-spotify --setup\n",
             title="Like Spotify — setup required",
         )
-        return 2
+        return None, 2, cfg
 
     provider = _common.make_provider(client_id)
     if not provider.has_tokens:
@@ -79,7 +85,14 @@ def _run_like_once() -> int:
             "Not authenticated. Run:\n\n    like-spotify --setup\n",
             title="Like Spotify — auth required",
         )
-        return 2
+        return None, 2, cfg
+    return provider, None, cfg
+
+
+def _run_like_once() -> int:
+    provider, err, cfg = _resolved_provider_or_hint()
+    if provider is None:
+        return err
 
     feedback = CliFeedback()
     storage = _common.build_storage(cfg)
@@ -90,23 +103,23 @@ def _run_like_once() -> int:
         storage=storage,
         post_like_actions=post_actions,
     )
-    trigger = make_one_shot_cli_trigger()
+    return _common.run_one_shot(pipeline, feedback)
 
-    async def emit() -> None:
-        await pipeline.run_once()
 
-    async def run() -> None:
-        try:
-            await trigger.start(emit)
-        finally:
-            await trigger.stop()
+def _run_remove_once() -> int:
+    provider, err, cfg = _resolved_provider_or_hint()
+    if provider is None:
+        return err
 
-    asyncio.run(run())
-
-    # Exit code follows the like outcome — useful in scripts.
-    if not feedback.calls:
-        return 1
-    return 0 if feedback.calls[-1][0] else 1
+    feedback = CliFeedback()
+    pipeline = _common.build_remove_pipeline(cfg, provider, feedback)
+    if pipeline is None:
+        _common.msgbox(
+            "No archive playlist configured. Run:\n\n    like-spotify --setup\n",
+            title="Like Spotify — setup required",
+        )
+        return 2
+    return _common.run_one_shot(pipeline, feedback)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -119,6 +132,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "like-once":
         return _run_like_once()
+    if args.command == "remove-once":
+        return _run_remove_once()
 
     # Default `run` on a non-tray platform: tell the user what works.
     print(_no_tray_message(), file=sys.stderr)

--- a/like_spotify/hosts/windows.py
+++ b/like_spotify/hosts/windows.py
@@ -177,7 +177,9 @@ def _msgbox(text: str, title: str = "Like Spotify", icon: int = 0x10) -> None:
 
 
 def _resolved_provider_or_hint():
-    """(provider, None) when ready, else (None, exit_code) after a hint box."""
+    """(provider, None, cfg) when ready, else (None, exit_code, cfg) after a
+    hint box. Mirrors the `_stub.py` copy — cfg is returned either way so the
+    caller can build the pipeline without reloading config."""
     cfg = _common.load_config()
     client_id = _common.resolve_client_id(cfg)
     if not client_id:

--- a/like_spotify/hosts/windows.py
+++ b/like_spotify/hosts/windows.py
@@ -22,9 +22,6 @@ import time
 from pathlib import Path
 
 from like_spotify.core.pipeline import Pipeline
-from like_spotify.extensions.one_shot_cli_trigger import (
-    TRIGGER as make_one_shot_cli_trigger,
-)
 from like_spotify.extensions.tray_hotkey_trigger import (
     DEFAULT_HOTKEY,
     TRIGGER as make_tray_hotkey_trigger,
@@ -80,8 +77,12 @@ class TrayFeedback:
     def attach(self, icon) -> None:
         self._icon = icon
 
-    def __call__(self, success: bool, title: str, message: str) -> None:
-        threading.Thread(target=self._beep, args=(success,), daemon=True).start()
+    def __call__(
+        self, success: bool, title: str, message: str, *, kind: str = "like"
+    ) -> None:
+        threading.Thread(
+            target=self._beep, args=(success, kind), daemon=True
+        ).start()
         threading.Thread(target=self._flash, args=(success,), daemon=True).start()
         if self._icon is not None:
             try:
@@ -96,14 +97,27 @@ class TrayFeedback:
         time.sleep(0.4)
         self._icon.icon = self._icon_default
 
-    def _beep(self, success: bool) -> None:
+    def _beep(self, success: bool, kind: str) -> None:
+        """Audible confirmation through the default sound device.
+
+        Uses `MessageBeep` (plays a system event sound via the default
+        output) rather than `Beep` (a PC-speaker / system-timer tone that
+        is silent on most modern laptops — the root cause of "no sound").
+        Distinct tones per outcome so like / remove / error are
+        distinguishable without looking at the tray:
+
+            like   → MB_ICONASTERISK   (0x40)
+            remove → MB_ICONEXCLAMATION (0x30)
+            error  → MB_ICONHAND        (0x10)
+        """
         import winsound
 
-        if success:
-            winsound.Beep(880, 80)
-            winsound.Beep(1100, 80)
+        if not success:
+            winsound.MessageBeep(0x10)
+        elif kind == "remove":
+            winsound.MessageBeep(0x30)
         else:
-            winsound.Beep(300, 200)
+            winsound.MessageBeep(0x40)
 
     @property
     def default_icon(self):
@@ -159,10 +173,11 @@ def _msgbox(text: str, title: str = "Like Spotify", icon: int = 0x10) -> None:
     _common.msgbox(text, title)
 
 
-# ── like-once subcommand (Windows still supports it) ───────────────────
+# ── one-shot subcommands (Windows still supports them) ─────────────────
 
 
-def _run_like_once() -> int:
+def _resolved_provider_or_hint():
+    """(provider, None) when ready, else (None, exit_code) after a hint box."""
     cfg = _common.load_config()
     client_id = _common.resolve_client_id(cfg)
     if not client_id:
@@ -170,15 +185,21 @@ def _run_like_once() -> int:
             "Not configured. Run from a terminal:\n\n    like-spotify --setup\n",
             title="Like Spotify — setup required",
         )
-        return 2
-
+        return None, 2, cfg
     provider = _common.make_provider(client_id)
     if not provider.has_tokens:
         _msgbox(
             "Not authenticated. Run from a terminal:\n\n    like-spotify --setup\n",
             title="Like Spotify — auth required",
         )
-        return 2
+        return None, 2, cfg
+    return provider, None, cfg
+
+
+def _run_like_once() -> int:
+    provider, err, cfg = _resolved_provider_or_hint()
+    if provider is None:
+        return err
 
     feedback = CliFeedback()
     storage = _common.build_storage(cfg)
@@ -189,22 +210,24 @@ def _run_like_once() -> int:
         storage=storage,
         post_like_actions=post_actions,
     )
-    trigger = make_one_shot_cli_trigger()
+    return _common.run_one_shot(pipeline, feedback)
 
-    async def emit() -> None:
-        await pipeline.run_once()
 
-    async def run() -> None:
-        try:
-            await trigger.start(emit)
-        finally:
-            await trigger.stop()
+def _run_remove_once() -> int:
+    provider, err, cfg = _resolved_provider_or_hint()
+    if provider is None:
+        return err
 
-    asyncio.run(run())
-
-    if not feedback.calls:
-        return 1
-    return 0 if feedback.calls[-1][0] else 1
+    feedback = CliFeedback()
+    pipeline = _common.build_remove_pipeline(cfg, provider, feedback)
+    if pipeline is None:
+        _msgbox(
+            "No archive playlist configured. Run from a terminal:\n\n"
+            "    like-spotify --setup\n",
+            title="Like Spotify — setup required",
+        )
+        return 2
+    return _common.run_one_shot(pipeline, feedback)
 
 
 # ── Main ───────────────────────────────────────────────────────────────
@@ -219,6 +242,8 @@ def main(argv: list[str] | None = None) -> int:
         return _common.do_setup(reauth=args.reauth)
     if args.command == "like-once":
         return _run_like_once()
+    if args.command == "remove-once":
+        return _run_remove_once()
 
     cfg = _common.load_config()
     client_id = _common.resolve_client_id(cfg)
@@ -251,6 +276,17 @@ def main(argv: list[str] | None = None) -> int:
     )
     trigger = make_tray_hotkey_trigger(hotkey=hotkey)
 
+    # ── Second hotkey: remove-without-like (only when an archive is set) ──
+    # Skip when no archive playlist is configured (nothing to remove from)
+    # or when the remove hotkey collides with the like hotkey — registering
+    # two handlers on one combo would fire both pipelines per press.
+    remove_hotkey = _common.resolve_remove_hotkey(cfg)
+    remove_pipeline = _common.build_remove_pipeline(cfg, provider, feedback)
+    remove_enabled = remove_pipeline is not None and remove_hotkey != hotkey
+    remove_trigger = (
+        make_tray_hotkey_trigger(hotkey=remove_hotkey) if remove_enabled else None
+    )
+
     loop = asyncio.new_event_loop()
     loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
     loop_thread.start()
@@ -258,7 +294,14 @@ def main(argv: list[str] | None = None) -> int:
     async def emit() -> None:
         await pipeline.run_once()
 
+    async def emit_remove() -> None:
+        await remove_pipeline.run_once()
+
     asyncio.run_coroutine_threadsafe(trigger.start(emit), loop).result()
+    if remove_trigger is not None:
+        asyncio.run_coroutine_threadsafe(
+            remove_trigger.start(emit_remove), loop
+        ).result()
 
     # Tray menu (runs on the calling thread — main).
     import pystray  # local import: heavy
@@ -266,15 +309,21 @@ def main(argv: list[str] | None = None) -> int:
     def on_like(_icon, _item):
         asyncio.run_coroutine_threadsafe(pipeline.run_once(), loop)
 
+    def on_remove(_icon, _item):
+        asyncio.run_coroutine_threadsafe(remove_pipeline.run_once(), loop)
+
     def on_toggle_autostart(icon, _item):
         _autostart_set(not _autostart_enabled())
         icon.update_menu()
 
     def on_quit(icon, _item):
-        try:
-            asyncio.run_coroutine_threadsafe(trigger.stop(), loop).result(timeout=2)
-        except Exception:
-            pass
+        for t in (trigger, remove_trigger):
+            if t is None:
+                continue
+            try:
+                asyncio.run_coroutine_threadsafe(t.stop(), loop).result(timeout=2)
+            except Exception:
+                pass
         loop.call_soon_threadsafe(loop.stop)
         icon.stop()
 
@@ -282,6 +331,14 @@ def main(argv: list[str] | None = None) -> int:
         pystray.MenuItem(
             f"Like current track  [{hotkey.upper()}]", on_like, default=True
         ),
+    ]
+    if remove_enabled:
+        menu_items.append(
+            pystray.MenuItem(
+                f"Remove from archive  [{remove_hotkey.upper()}]", on_remove
+            )
+        )
+    menu_items += [
         pystray.Menu.SEPARATOR,
         pystray.MenuItem(
             "Start with Windows",
@@ -302,11 +359,11 @@ def main(argv: list[str] | None = None) -> int:
 
     def _startup_notify():
         time.sleep(0.5)
+        msg = f"Press {hotkey.upper()} to like the current track"
+        if remove_enabled:
+            msg += f"\n{remove_hotkey.upper()} removes it from the archive"
         try:
-            icon.notify(
-                f"Press {hotkey.upper()} to like the current track",
-                "Like Spotify",
-            )
+            icon.notify(msg, "Like Spotify")
         except Exception:
             pass
 

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -106,3 +106,14 @@ def test_cli_feedback_omits_dash_when_message_empty(capsys) -> None:
     fb(False, "Nothing playing", "")
     err = capsys.readouterr().err.strip()
     assert err == "[err] Nothing playing"
+
+
+def test_cli_feedback_accepts_kind_keyword(capsys) -> None:
+    """The remove pipeline calls feedback with kind="remove"; CLI has no
+    audio but must accept (and record) the keyword for parity."""
+    fb = _stub.CliFeedback()
+    fb(True, "Removed from Archive", "Song — Artist", kind="remove")
+    out = capsys.readouterr().out
+    assert "[ok] Removed from Archive — Song — Artist" in out
+    assert fb.calls == [(True, "Removed from Archive", "Song — Artist")]
+    assert fb.kinds == ["remove"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -434,12 +434,14 @@ class FakeRemoveProvider(MusicProvider):
         get_raises: Exception | None = None,
         find_raises: Exception | None = None,
         remove_raises: Exception | None = None,
+        remove_raises_once: bool = False,
     ):
         self._track = track
         self._playlist_id = playlist_id
         self._get_raises = get_raises
         self._find_raises = find_raises
         self._remove_raises = remove_raises
+        self._remove_raises_once = remove_raises_once
         self.find_calls: list[str] = []
         self.remove_calls: list[tuple[str, str]] = []
 
@@ -467,7 +469,9 @@ class FakeRemoveProvider(MusicProvider):
         self, track_id: str, playlist_id: str
     ) -> None:
         self.remove_calls.append((track_id, playlist_id))
-        if self._remove_raises is not None:
+        if self._remove_raises is not None and (
+            not self._remove_raises_once or len(self.remove_calls) == 1
+        ):
             raise self._remove_raises
 
 
@@ -560,6 +564,31 @@ async def test_remove_pipeline_remove_failure_surfaces() -> None:
 
     assert fb.calls[0][:2] == (False, "Remove failed")
     assert "boom" in fb.calls[0][2]
+
+
+@pytest.mark.asyncio
+async def test_remove_pipeline_drops_cache_after_remove_failure() -> None:
+    """A remove failure (stale id — playlist deleted/renamed) must drop the
+    cached id so the next press re-resolves instead of failing forever."""
+    provider = FakeRemoveProvider(
+        track=_track("trk1"),
+        playlist_id="pl1",
+        remove_raises=RuntimeError("gone"),
+        remove_raises_once=True,
+    )
+    fb = Feedback()
+    pipe = RemoveFromPlaylistPipeline(
+        provider=provider, feedback=fb, playlist_name="My Archive"
+    )
+
+    await pipe.run_once()  # resolves pl1, remove raises → cache dropped
+    await pipe.run_once()  # re-resolves, then succeeds
+
+    # find called twice proves the cache was invalidated by the failure.
+    assert provider.find_calls == ["My Archive", "My Archive"]
+    assert provider.remove_calls == [("trk1", "pl1"), ("trk1", "pl1")]
+    assert fb.calls[0][:2] == (False, "Remove failed")
+    assert fb.calls[1][0] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -16,7 +16,7 @@ import pytest
 
 from like_spotify.core.actions import PostLikeAction, PreLikeAction
 from like_spotify.core.music_provider import MusicProvider
-from like_spotify.core.pipeline import Pipeline
+from like_spotify.core.pipeline import Pipeline, RemoveFromPlaylistPipeline
 from like_spotify.core.storage import Storage
 from like_spotify.core.types import CurrentTrack, LikeContext
 
@@ -101,9 +101,13 @@ class FakeStorage(Storage):
 class Feedback:
     def __init__(self) -> None:
         self.calls: list[tuple[bool, str, str]] = []
+        self.kinds: list[str] = []
 
-    def __call__(self, success: bool, title: str, message: str) -> None:
+    def __call__(
+        self, success: bool, title: str, message: str, *, kind: str = "like"
+    ) -> None:
         self.calls.append((success, title, message))
+        self.kinds.append(kind)
 
 
 def _track(track_id: str = "abc123") -> CurrentTrack:
@@ -415,3 +419,183 @@ async def test_post_action_failure_does_not_abort_chain() -> None:
 
     assert broken.calls and healthy.calls
     assert fb.calls[0][0] is True  # Like still reported as success.
+
+
+# ── #43: RemoveFromPlaylistPipeline (remove-without-like hotkey) ────────
+
+
+class FakeRemoveProvider(MusicProvider):
+    """Provider with the Spotify-flavored playlist API the remove flow needs."""
+
+    def __init__(
+        self,
+        track: CurrentTrack | None,
+        playlist_id: str | None = "pl1",
+        get_raises: Exception | None = None,
+        find_raises: Exception | None = None,
+        remove_raises: Exception | None = None,
+    ):
+        self._track = track
+        self._playlist_id = playlist_id
+        self._get_raises = get_raises
+        self._find_raises = find_raises
+        self._remove_raises = remove_raises
+        self.find_calls: list[str] = []
+        self.remove_calls: list[tuple[str, str]] = []
+
+    async def get_currently_playing(self) -> CurrentTrack | None:
+        if self._get_raises is not None:
+            raise self._get_raises
+        return self._track
+
+    async def like(self, track: CurrentTrack) -> None:  # pragma: no cover
+        raise AssertionError("remove flow must not like")
+
+    async def is_liked(self, track: CurrentTrack) -> bool:  # pragma: no cover
+        raise AssertionError("remove flow must not probe is_liked")
+
+    async def user_id(self) -> str:  # pragma: no cover
+        return "user-id"
+
+    async def find_playlist_by_name(self, name: str) -> str | None:
+        self.find_calls.append(name)
+        if self._find_raises is not None:
+            raise self._find_raises
+        return self._playlist_id
+
+    async def remove_track_from_playlist(
+        self, track_id: str, playlist_id: str
+    ) -> None:
+        self.remove_calls.append((track_id, playlist_id))
+        if self._remove_raises is not None:
+            raise self._remove_raises
+
+
+@pytest.mark.asyncio
+async def test_remove_pipeline_removes_current_track_without_liking() -> None:
+    provider = FakeRemoveProvider(track=_track("trk1"), playlist_id="pl1")
+    fb = Feedback()
+
+    await RemoveFromPlaylistPipeline(
+        provider=provider, feedback=fb, playlist_name="My Archive"
+    ).run_once()
+
+    assert provider.remove_calls == [("trk1", "pl1")]
+    assert provider.find_calls == ["My Archive"]
+    assert fb.calls[0][0] is True
+    assert fb.calls[0][1] == "Removed from My Archive"
+    assert fb.kinds == ["remove"]
+
+
+@pytest.mark.asyncio
+async def test_remove_pipeline_nothing_playing() -> None:
+    provider = FakeRemoveProvider(track=None)
+    fb = Feedback()
+
+    await RemoveFromPlaylistPipeline(
+        provider=provider, feedback=fb, playlist_name="My Archive"
+    ).run_once()
+
+    assert provider.remove_calls == []
+    assert fb.calls == [(False, "Nothing playing", "")]
+    assert fb.kinds == ["remove"]
+
+
+@pytest.mark.asyncio
+async def test_remove_pipeline_playlist_not_found_does_not_cache() -> None:
+    provider = FakeRemoveProvider(track=_track("trk1"), playlist_id=None)
+    fb = Feedback()
+    pipe = RemoveFromPlaylistPipeline(
+        provider=provider, feedback=fb, playlist_name="Ghost"
+    )
+
+    await pipe.run_once()
+    await pipe.run_once()
+
+    assert provider.remove_calls == []
+    # Not cached → re-resolved on the second press.
+    assert provider.find_calls == ["Ghost", "Ghost"]
+    assert fb.calls[0] == (False, "Playlist not found", "Ghost")
+
+
+@pytest.mark.asyncio
+async def test_remove_pipeline_caches_playlist_id_after_success() -> None:
+    provider = FakeRemoveProvider(track=_track("trk1"), playlist_id="pl1")
+    fb = Feedback()
+    pipe = RemoveFromPlaylistPipeline(
+        provider=provider, feedback=fb, playlist_name="My Archive"
+    )
+
+    await pipe.run_once()
+    await pipe.run_once()
+
+    # find resolved once; both presses removed.
+    assert provider.find_calls == ["My Archive"]
+    assert provider.remove_calls == [("trk1", "pl1"), ("trk1", "pl1")]
+
+
+@pytest.mark.asyncio
+async def test_remove_pipeline_provider_without_playlist_api() -> None:
+    provider = FakeProvider(track=_track("trk1"))  # like-flow only, no playlist API
+    fb = Feedback()
+
+    await RemoveFromPlaylistPipeline(
+        provider=provider, feedback=fb, playlist_name="My Archive"
+    ).run_once()
+
+    assert fb.calls[0][:2] == (False, "Remove unsupported")
+    assert fb.kinds == ["remove"]
+
+
+@pytest.mark.asyncio
+async def test_remove_pipeline_remove_failure_surfaces() -> None:
+    provider = FakeRemoveProvider(
+        track=_track("trk1"), playlist_id="pl1", remove_raises=RuntimeError("boom")
+    )
+    fb = Feedback()
+
+    await RemoveFromPlaylistPipeline(
+        provider=provider, feedback=fb, playlist_name="My Archive"
+    ).run_once()
+
+    assert fb.calls[0][:2] == (False, "Remove failed")
+    assert "boom" in fb.calls[0][2]
+
+
+@pytest.mark.asyncio
+async def test_remove_pipeline_lookup_failure_does_not_cache() -> None:
+    provider = FakeRemoveProvider(
+        track=_track("trk1"), find_raises=RuntimeError("net")
+    )
+    fb = Feedback()
+    pipe = RemoveFromPlaylistPipeline(
+        provider=provider, feedback=fb, playlist_name="My Archive"
+    )
+
+    await pipe.run_once()
+    await pipe.run_once()
+
+    assert provider.find_calls == ["My Archive", "My Archive"]
+    assert provider.remove_calls == []
+    assert fb.calls[0][:2] == (False, "Playlist lookup failed")
+
+
+@pytest.mark.asyncio
+async def test_remove_pipeline_get_currently_playing_failure() -> None:
+    provider = FakeRemoveProvider(track=None, get_raises=RuntimeError("api down"))
+    fb = Feedback()
+
+    await RemoveFromPlaylistPipeline(
+        provider=provider, feedback=fb, playlist_name="My Archive"
+    ).run_once()
+
+    assert fb.calls[0][:2] == (False, "Error")
+    assert provider.remove_calls == []
+
+
+def test_remove_pipeline_rejects_blank_playlist_name() -> None:
+    with pytest.raises(ValueError):
+        RemoveFromPlaylistPipeline(
+            provider=FakeRemoveProvider(track=None), feedback=Feedback(),
+            playlist_name="   ",
+        )

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -85,6 +84,7 @@ def test_setup_supabase_writes_config_and_runs_oauth(
         "supabase",            # Storage backend
         "https://x.supabase.co",  # Supabase URL
         "anon-key-xyz",        # Supabase anon key
+        "",                    # [3/4] archive playlist name — blank = skip
         # autostart prompt only fires on win32 — we patch sys.platform off
     ]
     monkeypatch.setattr("builtins.input", _scripted_input(answers))
@@ -109,6 +109,7 @@ def test_setup_skips_spotify_oauth_when_tokens_present(
     monkeypatch.setattr("builtins.input", _scripted_input([
         "abc123client",
         "none",
+        "",  # [3/4] archive — skip
     ]))
     monkeypatch.setattr(_common.sys, "platform", "linux")
 
@@ -125,6 +126,7 @@ def test_setup_reauth_forces_oauth_even_with_tokens(
     monkeypatch.setattr("builtins.input", _scripted_input([
         "abc123client",
         "none",
+        "",  # [3/4] archive — skip
     ]))
     monkeypatch.setattr(_common.sys, "platform", "linux")
 
@@ -151,6 +153,7 @@ def test_setup_storage_none_writes_backend_marker(
     monkeypatch.setattr("builtins.input", _scripted_input([
         "abc123client",
         "none",
+        "",  # [3/4] archive — skip
     ]))
     monkeypatch.setattr(_common.sys, "platform", "linux")
 
@@ -161,6 +164,51 @@ def test_setup_storage_none_writes_backend_marker(
     # No supabase / sheets blocks created.
     assert "supabase" not in cfg or not cfg.get("supabase")
     assert "sheets" not in cfg or not cfg.get("sheets")
+
+
+def test_setup_archive_writes_playlist_and_remove_hotkey(
+    tmp_paths, fake_provider, monkeypatch
+) -> None:
+    """[3/4]: a playlist name + remove hotkey land in config so the
+    archive PostLikeAction AND the remove-without-like trigger both wire."""
+    monkeypatch.setattr("builtins.input", _scripted_input([
+        "abc123client",
+        "none",
+        "Discover Weekly Archive",  # [3/4] archive playlist name
+        "ctrl+shift+alt+e",         # [3/4] remove hotkey (override default)
+    ]))
+    monkeypatch.setattr(_common.sys, "platform", "linux")
+
+    rc = _common.do_setup(reauth=False)
+    assert rc == 0
+    cfg = _common.load_config()
+    assert cfg["actions"]["archive_remove"]["playlist_name"] == "Discover Weekly Archive"
+    assert cfg["actions"]["archive_remove"]["enabled"] is True
+    assert cfg["trigger"]["remove_hotkey"] == "ctrl+shift+alt+e"
+    # The same name drives the like-flow archive action.
+    assert _common.resolve_archive_playlist_name(cfg) == "Discover Weekly Archive"
+
+
+def test_setup_archive_blank_disables_previously_set_name(
+    tmp_paths, fake_provider, monkeypatch
+) -> None:
+    """Re-running and clearing the name must turn the feature off, not
+    leave a stale playlist silently configured."""
+    _common.save_config({
+        "actions": {"archive_remove": {"playlist_name": "Old", "enabled": True}},
+    })
+    monkeypatch.setattr("builtins.input", _scripted_input([
+        "abc123client",
+        "none",
+        "-",  # [3/4] archive — '-' turns it off (blank would KEEP it)
+    ]))
+    monkeypatch.setattr(_common.sys, "platform", "linux")
+
+    rc = _common.do_setup(reauth=False)
+    assert rc == 0
+    cfg = _common.load_config()
+    assert cfg["actions"]["archive_remove"]["enabled"] is False
+    assert _common.resolve_archive_playlist_name(cfg) == ""
 
 
 def test_setup_aborts_when_supabase_creds_blank(
@@ -188,6 +236,7 @@ def test_setup_sheets_branch_runs_google_oauth(
         "spreadsheet-id-xyz",
         "google-client.apps.googleusercontent.com",
         "google-secret",
+        "",  # [3/4] archive — skip
     ]))
     monkeypatch.setattr(_common.sys, "platform", "linux")
 
@@ -229,6 +278,7 @@ def test_setup_sheets_skips_google_oauth_when_refresh_token_present(
         "sheets",
         "spreadsheet-id-xyz",
         # NO client_id/secret prompts because refresh_token is present.
+        "",  # [3/4] archive — skip
     ]))
     monkeypatch.setattr(_common.sys, "platform", "linux")
 
@@ -310,6 +360,46 @@ def test_build_storage_missing_supabase_creds_returns_none(tmp_paths) -> None:
 
 def test_build_storage_missing_spreadsheet_id_returns_none(tmp_paths) -> None:
     assert _common.build_storage({"storage": {"backend": "sheets"}}) is None
+
+
+# ── archive name resolution + remove-pipeline builder (#43) ────────────
+
+
+def test_resolve_archive_name_reads_nested_key() -> None:
+    cfg = {"actions": {"archive_remove": {"playlist_name": "Arch"}}}
+    assert _common.resolve_archive_playlist_name(cfg) == "Arch"
+
+
+def test_resolve_archive_name_legacy_flat_key() -> None:
+    assert _common.resolve_archive_playlist_name({"archive_playlist_name": "Old"}) == "Old"
+
+
+def test_resolve_archive_name_honors_disabled_flag() -> None:
+    cfg = {"actions": {"archive_remove": {"playlist_name": "Arch", "enabled": False}}}
+    assert _common.resolve_archive_playlist_name(cfg) == ""
+
+
+def test_resolve_archive_name_empty_when_unset() -> None:
+    assert _common.resolve_archive_playlist_name({}) == ""
+
+
+def test_build_remove_pipeline_none_when_no_archive() -> None:
+    assert _common.build_remove_pipeline({}, object(), lambda *a, **k: None) is None
+
+
+def test_build_remove_pipeline_built_when_configured() -> None:
+    cfg = {"actions": {"archive_remove": {"playlist_name": "Arch"}}}
+    pipe = _common.build_remove_pipeline(cfg, object(), lambda *a, **k: None)
+    assert pipe is not None
+    assert pipe._playlist_name == "Arch"
+
+
+def test_resolve_remove_hotkey_default_and_override() -> None:
+    assert _common.resolve_remove_hotkey({}) == _common.DEFAULT_REMOVE_HOTKEY
+    assert (
+        _common.resolve_remove_hotkey({"trigger": {"remove_hotkey": "ctrl+x"}})
+        == "ctrl+x"
+    )
 
 
 # ── print_config_paths surfaces all three paths ────────────────────────

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -211,6 +211,51 @@ def test_setup_archive_blank_disables_previously_set_name(
     assert _common.resolve_archive_playlist_name(cfg) == ""
 
 
+def test_setup_archive_overwrites_existing_name(
+    tmp_paths, fake_provider, monkeypatch
+) -> None:
+    """Typing a *different* name replaces the old one (the rename path) and
+    keeps the feature enabled — guards the one-line overwrite from refactors."""
+    _common.save_config({
+        "actions": {"archive_remove": {"playlist_name": "Old", "enabled": True}},
+    })
+    monkeypatch.setattr("builtins.input", _scripted_input([
+        "abc123client",
+        "none",
+        "New Archive",        # [3/4] archive — rename
+        "ctrl+shift+alt+q",   # [3/4] remove hotkey
+    ]))
+    monkeypatch.setattr(_common.sys, "platform", "linux")
+
+    rc = _common.do_setup(reauth=False)
+    assert rc == 0
+    cfg = _common.load_config()
+    assert cfg["actions"]["archive_remove"]["playlist_name"] == "New Archive"
+    assert cfg["actions"]["archive_remove"]["enabled"] is True
+    assert _common.resolve_archive_playlist_name(cfg) == "New Archive"
+
+
+def test_setup_archive_dash_when_nothing_configured_disables_cleanly(
+    tmp_paths, fake_provider, monkeypatch, capsys
+) -> None:
+    """'-' with no prior name is idempotent: feature stays off and the
+    message acknowledges the explicit off-switch rather than 'Skipped'."""
+    monkeypatch.setattr("builtins.input", _scripted_input([
+        "abc123client",
+        "none",
+        "-",  # [3/4] archive — explicit off with nothing set
+    ]))
+    monkeypatch.setattr(_common.sys, "platform", "linux")
+
+    rc = _common.do_setup(reauth=False)
+    assert rc == 0
+    cfg = _common.load_config()
+    assert cfg["actions"]["archive_remove"]["enabled"] is False
+    assert "playlist_name" not in cfg["actions"]["archive_remove"]
+    assert _common.resolve_archive_playlist_name(cfg) == ""
+    assert "Already disabled" in capsys.readouterr().out
+
+
 def test_setup_aborts_when_supabase_creds_blank(
     tmp_paths, fake_provider, monkeypatch, capsys
 ) -> None:


### PR DESCRIPTION
Closes #43.

Three coupled gaps in Discover-Weekly-archive curation on the desktop (Python) host.

## 1. Bug — archive-remove unreachable via the wizard
`ArchiveRemoveAction` (#23) is implemented and tested, but the `--setup` wizard (#28) never prompted for the archive playlist name. `build_post_actions` gates the action on a non-empty name, so anyone who configured via `--setup` had it **silently disabled** — AC #23 ("like a track in the archive → removed") was unreachable in practice.

Fix: new wizard step `[3/4] Discover Weekly clean-up` writes `actions.archive_remove.playlist_name` (+ `enabled`). `resolve_archive_playlist_name` is now the single source of truth that both the like-flow action and the new pipeline read (reads `actions.archive_remove.playlist_name` → `actions.archive_playlist_name` → legacy flat key).

## 2. Bug — no reliable audio
`winsound.Beep` is the system-timer tone — inaudible on most Win10/11 laptops, and `like-once`/CLI had no beep at all. Switched `TrayFeedback` to `winsound.MessageBeep` (plays through the default sound device) with distinct tones per action: **like** (asterisk) / **remove** (exclamation) / **error** (hand).

## 3. Feature — second hotkey: remove WITHOUT liking
Today the only way to drop a Discover-Weekly track is to like it. For tracks the user does *not* like, a second global hotkey (default `Ctrl+Shift+Alt+Q`) removes the current track from the archive playlist without liking it. Headphones afford one media-button pattern (Android); the desktop can bind arbitrarily many hotkeys.

- New `RemoveFromPlaylistPipeline` in `core/pipeline.py` — caches the resolved playlist id, never caches a miss (so a later press re-resolves).
- Exposed on every host as `like-spotify remove-once`.
- Windows tray host binds a second global hotkey + tray menu item, **skipped** if it collides with the like hotkey or no archive name is configured.

## Notes
- Shared one-shot driver (`run_one_shot`) + `_resolved_provider_or_hint` factored into `_common.py` to avoid duplicating the runner across like-once/remove-once × two hosts.
- Scope: desktop/Windows host only. Android port unaffected.

## Testing
- `pytest`: **151 passed** (+19), `ruff check`: clean.
- New `RemoveFromPlaylistPipeline` tests cover: track removed, nothing playing, playlist-not-found (no-cache), cache-after-success, provider without playlist API, remove failure, lookup failure (no-cache), playback-read failure, rejects blank name.
- Wizard tests for the new archive step (`-` token disables a previously-set name) + `resolve_archive_playlist_name` / `build_remove_pipeline` / `resolve_remove_hotkey` units.

## AC (issue #43)
- [x] `--setup` prompts for archive playlist name + remove hotkey; blank = disabled (back-compat)
- [x] Liking a track in the archive removes it (end-to-end reachable after `--setup`)
- [x] Second hotkey (default `Ctrl+Shift+Alt+Q`) removes current track without liking
- [x] Audio audible through default device + distinct per action
- [x] `RemoveFromPlaylistPipeline` unit-tested
- [x] README + CONTRIBUTING document `trigger.remove_hotkey` and `actions.archive_remove.playlist_name`
- [x] Scope: desktop/Windows host only

🤖 Generated with [Claude Code](https://claude.com/claude-code)