### PR TITLE
fix(desktop): normalize Supabase URL so /rest/v1 isn't doubled

### DIFF
--- a/like_spotify/extensions/supabase_storage/__init__.py
+++ b/like_spotify/extensions/supabase_storage/__init__.py
@@ -31,7 +31,7 @@ class SupabaseStorage(Storage):
     def __init__(self, url: str, anon_key: str, timeout: float = 5.0) -> None:
         if not url or not anon_key:
             raise ValueError("supabase url and anon_key are required")
-        self._url = url.rstrip("/")
+        self._url = _normalize_base_url(url)
         self._key = anon_key
         self._timeout = timeout
 
@@ -128,6 +128,24 @@ class SupabaseStorage(Storage):
         if not rows:
             return 0
         return int(rows[0].get("count", 0))
+
+
+def _normalize_base_url(url: str) -> str:
+    """Reduce any pasted Supabase URL to the project origin.
+
+    The dashboard shows two URLs: the project URL
+    (`https://<ref>.supabase.co`) and the REST endpoint
+    (`https://<ref>.supabase.co/rest/v1/`). Users paste either. Every
+    request builder here appends `/rest/v1/...`, so a base that already
+    carries `/rest/v1` would double the path and PostgREST returns
+    `404 PGRST125 "Invalid path specified in request URL"`. Strip a
+    trailing `/rest/v1` (and any surrounding slashes) so the suffix is
+    added exactly once.
+    """
+    base = url.strip().rstrip("/")
+    if base.endswith("/rest/v1"):
+        base = base[: -len("/rest/v1")].rstrip("/")
+    return base
 
 
 def _parse_count(body: str) -> int:

--- a/like_spotify/hosts/_common.py
+++ b/like_spotify/hosts/_common.py
@@ -391,6 +391,7 @@ def _setup_storage(cfg: dict, *, reauth: bool) -> None:
 
     if backend == "supabase":
         sb = cfg.setdefault("supabase", {})
+        print("    (project URL, e.g. https://<ref>.supabase.co — not the /rest/v1 endpoint)")
         sb["url"] = _prompt_secret("  Supabase URL", current=sb.get("url", ""))
         sb["anon_key"] = _prompt_secret(
             "  Supabase anon key", current=sb.get("anon_key", "")

--- a/tests/test_supabase_storage.py
+++ b/tests/test_supabase_storage.py
@@ -12,7 +12,10 @@ import pytest
 
 from like_spotify.core.errors import TransientError
 from like_spotify.core.types import CurrentTrack
-from like_spotify.extensions.supabase_storage import SupabaseStorage
+from like_spotify.extensions.supabase_storage import (
+    SupabaseStorage,
+    _normalize_base_url,
+)
 
 
 @dataclass
@@ -36,6 +39,44 @@ def test_constructor_rejects_empty_creds() -> None:
         SupabaseStorage(url="", anon_key="k")
     with pytest.raises(ValueError):
         SupabaseStorage(url="https://x.supabase.co", anon_key="")
+
+
+@pytest.mark.parametrize(
+    "given",
+    [
+        "https://x.supabase.co",
+        "https://x.supabase.co/",
+        "https://x.supabase.co/rest/v1",
+        "https://x.supabase.co/rest/v1/",
+        "  https://x.supabase.co/rest/v1/  ",
+    ],
+)
+def test_normalize_base_url_strips_rest_v1(given: str) -> None:
+    # Whichever URL the dashboard hands the user, it must reduce to the
+    # project origin so `/rest/v1/...` is appended exactly once.
+    assert _normalize_base_url(given) == "https://x.supabase.co"
+
+
+@pytest.mark.asyncio
+async def test_rpc_url_not_doubled_when_user_pastes_rest_endpoint(monkeypatch) -> None:
+    """Regression: pasting the `/rest/v1/` endpoint used to produce
+    `.../rest/v1/rest/v1/rpc/...` → 404 PGRST125."""
+    captured: dict[str, Any] = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        return FakeResponse(status_code=200, text="1")
+
+    monkeypatch.setattr(
+        "like_spotify.extensions.supabase_storage.requests.post", fake_post
+    )
+
+    storage = SupabaseStorage(
+        url="https://x.supabase.co/rest/v1/", anon_key="k"
+    )
+    await storage.record_artist_track("user-1", "art-1", "trk-1")
+
+    assert captured["url"] == "https://x.supabase.co/rest/v1/rpc/record_artist_track"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

On the user's machine, `follow-artist` crashed with:

```
follow-artist: record_artist_track failed: supabase rpc 404 PGRST125 "Invalid path specified in request URL"
```

Root cause: the user pasted the dashboard's **REST endpoint** (`https://<ref>.supabase.co/rest/v1/`) into the setup wizard's "Supabase URL" prompt. Every request builder in `SupabaseStorage` appends `/rest/v1/...`, so the stored base doubled the path → `.../rest/v1/rest/v1/rpc/record_artist_track` → PostgREST 404 PGRST125.

## Fix

- `_normalize_base_url()` reduces any pasted URL to the project origin — strips a trailing `/rest/v1` and surrounding slashes — so the suffix is appended exactly once. Handles all forms the dashboard hands out (project URL, REST endpoint, trailing slash, surrounding whitespace).
- Setup wizard prints a hint: *"project URL, e.g. https://<ref>.supabase.co — not the /rest/v1 endpoint"*.

## Tests

- `test_normalize_base_url_strips_rest_v1` — parametrized over 5 URL forms, all → `https://x.supabase.co`.
- `test_rpc_url_not_doubled_when_user_pastes_rest_endpoint` — regression: constructs storage with the `/rest/v1/` endpoint, asserts the captured RPC URL is the single-`/rest/v1` form.

Full suite: 160 passed, ruff clean.

`[no-issue]` — drive-by runtime fix surfaced by the user's own session; small and reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
