### PR TITLE
fix(desktop): autostart via pythonw + venv interpreter (no console flash)

### DIFF
--- a/like_spotify/hosts/windows.py
+++ b/like_spotify/hosts/windows.py
@@ -134,7 +134,14 @@ _AUTOSTART_NAME = "LikeSpotify"
 def _autostart_target() -> str:
     if getattr(sys, "frozen", False):
         return f'"{Path(sys.executable).resolve()}"'
-    return f'"{sys.executable}" -m like_spotify'
+    # Source / pipx install: launch through the interpreter that's running
+    # us (the pipx venv when installed that way). Prefer pythonw.exe so the
+    # tray app starts at login without a console window flashing on screen;
+    # fall back to python.exe if the GUI interpreter isn't present.
+    exe = Path(sys.executable)
+    pythonw = exe.with_name("pythonw.exe")
+    runner = pythonw if pythonw.exists() else exe
+    return f'"{runner}" -m like_spotify'
 
 
 def _autostart_enabled() -> bool:


### PR DESCRIPTION
## Problem

On the user's pipx-installed machine the desktop app **didn't launch at login** and gave **no sound** on the hotkey.

Root cause (one, not two): a stale PyInstaller build at `dist\LikeSpotify.exe` from before the switch to pipx. The `HKCU\…\Run` autostart key still pointed at that frozen exe, so login launched **old frozen code** — which uses the silent `winsound.Beep` (a PC-speaker / system-timer tone that's inaudible on this hardware) and predates the current config schema. The pipx build I'd been fixing (`winsound.MessageBeep`, audible — confirmed by an on-device beep test where the system "ding" played but the raw `Beep` tone did not) never ran on this machine.

## Fix

Point autostart at the pipx interpreter instead of the frozen build. `_autostart_target()` for the source/pipx install now prefers `pythonw.exe` (sibling of `sys.executable`) so the tray starts at login **without a console window flashing**, falling back to `python.exe` when the GUI interpreter isn't present. Frozen-build branch unchanged.

## Verification (on-device)

- Repointed the Run key via the app's own `_autostart_set(True)` → `"…\venvs\like-spotify\Scripts\pythonw.exe" -m like_spotify`.
- Launched that exact command from a neutral CWD (mimicking boot) → tray process stays up.
- Beep test confirmed `MessageBeep` (system ding) is audible on this machine while raw `Beep` is silent — validating the earlier `Beep → MessageBeep` switch.

No unit test added: `_autostart_target` is Windows-only platform glue (reads `sys.executable`, probes the filesystem for `pythonw.exe`) and `windows.py` isn't importable in the Linux CI job; verified live on the target machine instead. Matches the existing convention (the function had no test before).

`[no-issue]` — drive-by fix surfaced by the user's own session; small and reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
