### PR TITLE
fix(desktop): wait for shell + log autostart so login launch stops racing ([no-issue])

### DIFF
--- a/like_spotify/hosts/windows.py
+++ b/like_spotify/hosts/windows.py
@@ -459,14 +459,19 @@ def _run_resident_host() -> int:
         except Exception:
             pass
 
-    threading.Thread(target=_startup_notify, daemon=True).start()
-
     # Don't race the shell: at login the Run entry can fire before explorer
     # has built the notification area, and the icon add is then silently
     # dropped — process alive, no heart. Wait for the taskbar first.
-    if not _wait_for_shell():
-        _log("Shell_TrayWnd absent after 60s — adding tray icon anyway")
-    _log("shell ready — entering tray loop")
+    if _wait_for_shell():
+        _log("shell ready — entering tray loop")
+    else:
+        _log("Shell_TrayWnd absent after 60s — adding tray icon anyway, proceeding")
+
+    # Welcome balloon: its 0.5s delay is meant to land just after the icon
+    # appears, so start it only now. On a cold boot the shell wait above can
+    # run for seconds; firing earlier would call notify() before icon.run()
+    # exists, and the balloon would be silently dropped.
+    threading.Thread(target=_startup_notify, daemon=True).start()
     icon.run()
     return 0
 

--- a/like_spotify/hosts/windows.py
+++ b/like_spotify/hosts/windows.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import ctypes
+import os
 import sys
 import threading
 import time
@@ -239,6 +240,69 @@ def _run_remove_once() -> int:
     return _common.run_one_shot(pipeline, feedback)
 
 
+# ── Startup logging + shell-readiness ──────────────────────────────────
+#
+# The resident tray is launched at login by the HKCU\…\Run key through
+# pythonw.exe — no console, so a crash or a lost tray-icon add leaves no
+# trace and the heart silently never appears ("снова не запустилось").
+# Two coupled defenses:
+#   1. `_log` — append the launch context + any fatal traceback to a file,
+#      so the *next* failed boot is diagnosable by fact, not by guess.
+#   2. `_wait_for_shell` — at login the Run entry can fire before explorer
+#      has created the notification area (`Shell_TrayWnd`); adding the icon
+#      then is silently dropped. Block until the taskbar exists so we stop
+#      racing the shell. Post-login the window is already up → returns at
+#      once. The race is timing-dependent, which is why autostart works on
+#      one boot and not the next.
+
+
+def _log(msg: str) -> None:
+    """Append one timestamped line to `<config-dir>/startup.log` (best effort).
+
+    Path is derived from `_common.CONFIG_FILE` so tests that redirect the
+    config dir capture the log too, and so it sits next to config/tokens.
+    Never raises — logging must not be the thing that kills startup.
+    """
+    try:
+        log_file = _common.CONFIG_FILE.parent / "startup.log"
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        ts = time.strftime("%Y-%m-%d %H:%M:%S")
+        with log_file.open("a", encoding="utf-8") as f:
+            f.write(f"{ts} [pid {os.getpid()}] {msg}\n")
+    except Exception:
+        pass
+
+
+def _taskbar_present() -> bool:
+    """True when the shell notification area window exists.
+
+    Injectable seam: `_wait_for_shell` is the loop worth testing, and it
+    polls through here so tests can drive readiness without a real desktop.
+    """
+    return bool(ctypes.windll.user32.FindWindowW("Shell_TrayWnd", None))
+
+
+def _wait_for_shell(timeout: float = 60.0, interval: float = 0.5) -> bool:
+    """Block until the taskbar exists, or `timeout` seconds pass.
+
+    Returns True if the shell came up in time, False on timeout (or if the
+    shell API is unavailable — then we don't block, just proceed). Polls
+    every `interval` seconds. Returns immediately when the taskbar is
+    already present (the normal post-login case).
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            if _taskbar_present():
+                return True
+        except Exception:
+            # No Win32 shell API (non-Windows / unusual host) — don't hang.
+            return False
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(interval)
+
+
 # ── Main ───────────────────────────────────────────────────────────────
 
 
@@ -254,6 +318,25 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "remove-once":
         return _run_remove_once()
 
+    # Resident tray host — the login-launched path. Log the launch context
+    # and funnel any startup crash to the log before pythonw lets it die
+    # silently (the whole reason "снова не запустилось" left no trace).
+    _log(
+        f"launch — cwd={os.getcwd()} exe={sys.executable!r} "
+        f"frozen={getattr(sys, 'frozen', False)} argv={sys.argv[1:]}"
+    )
+    try:
+        return _run_resident_host()
+    except SystemExit:
+        raise  # single-instance guard / normal exit — not a fault
+    except BaseException:
+        import traceback
+
+        _log("FATAL during resident host startup:\n" + traceback.format_exc())
+        raise
+
+
+def _run_resident_host() -> int:
     cfg = _common.load_config()
     client_id = _common.resolve_client_id(cfg)
     if not client_id:
@@ -378,6 +461,12 @@ def main(argv: list[str] | None = None) -> int:
 
     threading.Thread(target=_startup_notify, daemon=True).start()
 
+    # Don't race the shell: at login the Run entry can fire before explorer
+    # has built the notification area, and the icon add is then silently
+    # dropped — process alive, no heart. Wait for the taskbar first.
+    if not _wait_for_shell():
+        _log("Shell_TrayWnd absent after 60s — adding tray icon anyway")
+    _log("shell ready — entering tray loop")
     icon.run()
     return 0
 

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 
 import pytest
 
-from like_spotify.hosts import _stub, select_host
+from like_spotify.hosts import _stub, select_host, windows
 
 
 # ── select_host() dispatch ─────────────────────────────────────────────
@@ -31,6 +31,68 @@ def test_select_host_picks_stub_off_win32(platform: str) -> None:
     with patch("like_spotify.hosts.sys.platform", platform):
         host = select_host()
     assert host.__module__ == "like_spotify.hosts._stub"
+
+
+# ── Windows resident-host startup: shell-readiness + logging ───────────
+#
+# The tray path itself needs a Win32 desktop (manual boundary), but the
+# two startup defenses added to fix login-time autostart races are pure
+# logic behind injectable seams, so they unit-test on any OS.
+
+
+def test_wait_for_shell_returns_at_once_when_taskbar_present(monkeypatch) -> None:
+    monkeypatch.setattr(windows, "_taskbar_present", lambda: True)
+    slept: list[float] = []
+    monkeypatch.setattr(windows.time, "sleep", lambda s: slept.append(s))
+
+    assert windows._wait_for_shell() is True
+    assert slept == []  # the common post-login case must not block
+
+
+def test_wait_for_shell_polls_until_taskbar_appears(monkeypatch) -> None:
+    states = iter([False, False, True])
+    monkeypatch.setattr(windows, "_taskbar_present", lambda: next(states))
+    slept: list[float] = []
+    monkeypatch.setattr(windows.time, "sleep", lambda s: slept.append(s))
+
+    assert windows._wait_for_shell(interval=0.01) is True
+    assert len(slept) == 2  # polled twice before the taskbar came up
+
+
+def test_wait_for_shell_times_out(monkeypatch) -> None:
+    monkeypatch.setattr(windows, "_taskbar_present", lambda: False)
+    monkeypatch.setattr(windows.time, "sleep", lambda s: None)
+
+    assert windows._wait_for_shell(timeout=0.0) is False
+
+
+def test_wait_for_shell_does_not_hang_when_probe_raises(monkeypatch) -> None:
+    def boom() -> bool:
+        raise OSError("no shell API")
+
+    monkeypatch.setattr(windows, "_taskbar_present", boom)
+    assert windows._wait_for_shell() is False
+
+
+def test_log_appends_line_to_config_dir(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "like_spotify.hosts._common.CONFIG_FILE", tmp_path / "config.json"
+    )
+    windows._log("hello world")
+
+    log = tmp_path / "startup.log"
+    assert log.exists()
+    contents = log.read_text(encoding="utf-8")
+    assert "hello world" in contents
+    assert f"[pid {windows.os.getpid()}]" in contents
+
+
+def test_log_never_raises_on_bad_path(monkeypatch) -> None:
+    # A config dir that can't be created must not take the process down.
+    monkeypatch.setattr(
+        "like_spotify.hosts._common.CONFIG_FILE", windows.Path("\x00bad") / "c.json"
+    )
+    windows._log("should be swallowed")  # must not raise
 
 
 # ── Stub host: surface CLI failures cleanly ────────────────────────────


### PR DESCRIPTION
## Problem
"снова не запустилось на старте компа" — the tray works when launched by hand but intermittently never appears after a login. Diagnosed on-device:

- pipx copy already == HEAD (not a stale build this time)
- `HKCU\…\Run` value correct **and** enabled (no `StartupApproved` disable)
- config/tokens live in `~/.like_spotify/` — no network/OneDrive dependency at boot
- launched manually (even pythonw from `system32`) → process alive, icon shows in the hidden-icons overflow, hotkeys work

→ Intermittent = **timing race at login**. The Run entry fires before explorer has built the notification area (`Shell_TrayWnd`); the icon add is silently dropped. `pythonw` has no console, so the failure left no trace.

## Fix
- **`_wait_for_shell()`** — block until `Shell_TrayWnd` exists (bounded 60s) before entering the tray loop. Returns immediately post-login. Polls through an injectable `_taskbar_present()` seam.
- **`_log()`** — append launch context + any fatal traceback to `~/.like_spotify/startup.log`; resident-host startup wrapped so a crash is recorded before `pythonw` swallows it. Honors the standing "fire-and-forget must capture stderr" rule — next failed boot is diagnosable by fact.
- `main()` split into arg-dispatch + `_run_resident_host()` for a clean crash-logging seam. Behaviour otherwise unchanged.

## Verification
- 6 new unit tests (shell-wait timing/timeout/raise + log write/never-raise); full python suite green (166 passed)
- Smoke test: launched `pythonw -m like_spotify` from `C:\Windows\System32` (mimics boot) → tray comes up, `startup.log` gets `launch …` + `shell ready — entering tray loop`
- pipx copy reinstalled so the **next boot runs this code** (the recurring trap: code fix without redeploying the pipx snapshot)

## Note
CI runs Flutter tests only — the Python suite isn't wired into `ci.yml`. Out of scope here; flagging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)