### PR TITLE
ci: run the Python desktop pytest suite as a merge gate ([no-issue])

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,30 @@ jobs:
       - run: flutter analyze
 
       - run: flutter test --coverage
+
+  pytest:
+    # Python desktop port under like_spotify/. Runs on windows-latest, not
+    # ubuntu: the host code (ctypes.windll single-instance guard, winreg
+    # autostart toggle, winsound feedback) only executes on Win32. On Linux
+    # those paths are reached only through monkeypatched test seams, so ubuntu
+    # would validate the test doubles rather than the shipped behaviour — and
+    # Win32 host code is exactly the regression surface this gate exists to
+    # cover (cf. PR #47). The desktop port is Windows-only (see pyproject
+    # classifiers), so CI runs on the platform it ships to.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - run: python -m pip install --upgrade pip
+
+      # Runtime deps (requests/keyboard/pystray/Pillow) come from the package;
+      # pyinstaller in the [dev] extra is a build-only tool, not needed here.
+      - run: pip install . pytest pytest-asyncio
+
+      - run: python -m pytest -q


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` only ran the Flutter suite (the `test` job: `flutter pub get` / `analyze` / `test --coverage` on ubuntu). The Python desktop port under `like_spotify/` has **166 pytest tests** in `tests/` that CI never executed.

A green `test` check therefore gave **false confidence on Python-only PRs**. Concretely, [#47](https://github.com/Osasuwu/like_spotify_mobile_app/pull/47) touched `like_spotify/hosts/windows.py` + `tests/test_hosts.py` and merged with a green `test` check that never ran those tests.

## Change

Add a second CI job, `pytest`:

- **`windows-latest`, Python 3.14** — installs the package (`pip install .`, pulling requests/keyboard/pystray/Pillow) plus `pytest pytest-asyncio`, then runs `python -m pytest -q`. `pyinstaller` (in the `[dev]` extra) is a build-only tool and is intentionally not installed.

### Why windows-latest, not ubuntu

The desktop port is **Windows-only software** (pyproject classifiers: `Environment :: Win32`, `Operating System :: Microsoft :: Windows`). The host code that PR #47 changed — `ctypes.windll` single-instance guard, `winreg` autostart toggle, `winsound` feedback, `_taskbar_present` shell probe — only executes on Win32. On Linux those paths are reached only through **monkeypatched test seams**, so an ubuntu run would validate the test doubles, not the shipped Win32 behaviour.

I confirmed the suite *would* collect on Linux (`keyboard`'s root check lives inside `build_device()`/`init()`, not at import; `pystray` is a lazy in-function import), so ubuntu was technically viable — but it adds no real signal for the one risk surface this gate exists to cover. Running on the target OS does.

## Merge gating

`main` was previously **unprotected** — nothing gated merges. This PR adds branch protection requiring the two deterministic CI checks (`test` + `pytest`) so the new suite actually blocks merges, per the repo merge-gate policy. The existing `review` job is left out of required contexts: this repo's `code-review.yml` has no verify-verdict post-step, so it signals that the bot ran, not a pass/fail verdict. `owner-queue-guard` / `require-linked-issue` workflows don't exist in this repo, so they're not required either — requiring a non-existent check would block every merge.

## Verification

166/166 pass locally on Windows + Python 3.14.3 (`python -m pytest -q` -> `166 passed in 1.53s`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
