### PR TITLE
fix(desktop): hidden VBScript autostart — no console window at login ([no-issue])

### DIFF
--- a/like_spotify/hosts/windows.py
+++ b/like_spotify/hosts/windows.py
@@ -132,17 +132,67 @@ _AUTOSTART_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
 _AUTOSTART_NAME = "LikeSpotify"
 
 
-def _autostart_target() -> str:
+def _resident_launch_command() -> str:
+    """The bare command that starts the resident tray (interpreter + module).
+
+    Prefers `pythonw.exe` so no console attaches in the common case; falls
+    back to `python.exe` when the GUI interpreter isn't beside it. The
+    autostart path wraps this again to stay hidden even when the venv
+    redirector re-execs the console interpreter at login — see
+    `_autostart_target`.
+    """
     if getattr(sys, "frozen", False):
         return f'"{Path(sys.executable).resolve()}"'
-    # Source / pipx install: launch through the interpreter that's running
-    # us (the pipx venv when installed that way). Prefer pythonw.exe so the
-    # tray app starts at login without a console window flashing on screen;
-    # fall back to python.exe if the GUI interpreter isn't present.
     exe = Path(sys.executable)
     pythonw = exe.with_name("pythonw.exe")
     runner = pythonw if pythonw.exists() else exe
     return f'"{runner}" -m like_spotify'
+
+
+def _autostart_vbs_path() -> Path:
+    """Where the hidden-launch VBScript lives — next to config/tokens."""
+    return _common.CONFIG_FILE.parent / "autostart_hidden.vbs"
+
+
+def _write_autostart_vbs() -> Path:
+    """Write a VBScript that launches the tray with a hidden window.
+
+    Why this exists: at login the pipx / pythoncore venv `pythonw.exe` is a
+    redirector that re-execs the *console* `python.exe` (confirmed in
+    startup.log — every real login logged `exe=…python.exe`), so a console
+    window appears despite Run pointing at `pythonw.exe`. The `pythonw`
+    preference alone can't win against the redirector's interpreter choice.
+
+    `WScript.Shell.Run(cmd, 0, False)` starts the process with `SW_HIDE`,
+    which the redirector forwards to the real interpreter — no console, no
+    flash. Only the autostart path goes through this; running `like-spotify`
+    from a terminal is unaffected (it never touches the VBScript).
+    """
+    cmd = _resident_launch_command()
+    # VBScript string literals escape a double-quote by doubling it.
+    arg = '"' + cmd.replace('"', '""') + '"'
+    vbs = (
+        'Set sh = CreateObject("WScript.Shell")\r\n'
+        f"sh.Run {arg}, 0, False\r\n"
+    )
+    path = _autostart_vbs_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(vbs, encoding="utf-8")
+    return path
+
+
+def _autostart_target() -> str:
+    """Registry Run value: launch the tray fully hidden at login.
+
+    A frozen windowed exe has no console, so it's launched directly. For the
+    source / pipx install we route through `wscript.exe` + a hidden-launch
+    VBScript so the console interpreter the venv redirector picks at login
+    never shows a window.
+    """
+    if getattr(sys, "frozen", False):
+        return _resident_launch_command()
+    vbs = _write_autostart_vbs()
+    return f'wscript.exe //B //Nologo "{vbs}"'
 
 
 def _autostart_enabled() -> bool:
@@ -282,6 +332,24 @@ def _taskbar_present() -> bool:
     return bool(ctypes.windll.user32.FindWindowW("Shell_TrayWnd", None))
 
 
+def _console_state() -> str:
+    """Describe this process's console window for the launch log.
+
+    The autostart fix hinges on *not* getting a visible console at login
+    (the pipx/pythoncore venv redirector re-execs the console interpreter —
+    see `_write_autostart_vbs`). Recording the console HWND and its
+    visibility makes the fix self-verifying: `hwnd=0` means a windowed
+    interpreter (ideal), `visible=False` means a console exists but is
+    hidden (the VBScript did its job). Best effort — never raises.
+    """
+    try:
+        hwnd = ctypes.windll.kernel32.GetConsoleWindow()
+        visible = bool(hwnd) and bool(ctypes.windll.user32.IsWindowVisible(hwnd))
+        return f"console_hwnd={hwnd} console_visible={visible}"
+    except Exception:
+        return "console_hwnd=? console_visible=?"
+
+
 def _wait_for_shell(timeout: float = 60.0, interval: float = 0.5) -> bool:
     """Block until the taskbar exists, or `timeout` seconds pass.
 
@@ -323,7 +391,8 @@ def main(argv: list[str] | None = None) -> int:
     # silently (the whole reason "снова не запустилось" left no trace).
     _log(
         f"launch — cwd={os.getcwd()} exe={sys.executable!r} "
-        f"frozen={getattr(sys, 'frozen', False)} argv={sys.argv[1:]}"
+        f"frozen={getattr(sys, 'frozen', False)} argv={sys.argv[1:]} "
+        f"{_console_state()}"
     )
     try:
         return _run_resident_host()

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -95,6 +95,65 @@ def test_log_never_raises_on_bad_path(monkeypatch) -> None:
     windows._log("should be swallowed")  # must not raise
 
 
+# ── Autostart hidden-launch wrapper ────────────────────────────────────
+#
+# At login the pipx/pythoncore venv `pythonw.exe` redirector re-execs the
+# *console* `python.exe`, so a console window appears despite Run pointing
+# at pythonw. The fix routes autostart through `wscript.exe` + a hidden
+# VBScript (`SW_HIDE`). The wrapper + quote escaping are pure logic.
+
+
+def test_write_autostart_vbs_emits_hidden_run(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "like_spotify.hosts._common.CONFIG_FILE", tmp_path / "config.json"
+    )
+    monkeypatch.setattr(
+        windows, "_resident_launch_command", lambda: '"C:\\py\\pythonw.exe" -m like_spotify'
+    )
+
+    path = windows._write_autostart_vbs()
+
+    assert path == tmp_path / "autostart_hidden.vbs"
+    vbs = path.read_text(encoding="utf-8")
+    assert "WScript.Shell" in vbs
+    # SW_HIDE (window style 0), non-blocking — this is what kills the console.
+    assert ", 0, False" in vbs
+    # Inner double-quotes must be VBScript-escaped (doubled) so the path
+    # with spaces survives.
+    assert '"""C:\\py\\pythonw.exe"" -m like_spotify"' in vbs
+
+
+def test_autostart_target_routes_through_wscript(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "like_spotify.hosts._common.CONFIG_FILE", tmp_path / "config.json"
+    )
+    monkeypatch.setattr(windows.sys, "frozen", False, raising=False)
+    monkeypatch.setattr(
+        windows, "_resident_launch_command", lambda: '"py.exe" -m like_spotify'
+    )
+
+    target = windows._autostart_target()
+
+    assert target.startswith("wscript.exe //B //Nologo ")
+    assert "autostart_hidden.vbs" in target
+    # The VBScript is written as a side effect so the Run value points at a
+    # real file.
+    assert (tmp_path / "autostart_hidden.vbs").exists()
+
+
+def test_autostart_target_frozen_launches_exe_directly(monkeypatch) -> None:
+    # A frozen windowed exe has no console — no VBScript indirection needed.
+    monkeypatch.setattr(windows.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(
+        windows.sys, "executable", "C:\\app\\LikeSpotify.exe", raising=False
+    )
+
+    target = windows._autostart_target()
+
+    assert "wscript" not in target
+    assert "LikeSpotify.exe" in target
+
+
 # ── Stub host: surface CLI failures cleanly ────────────────────────────
 
 


### PR DESCRIPTION
## Problem

After the login-race fix (#47), the Like Spotify tray app **does** start at login now — but it opens with a **visible console window**. (User: «теперь открывается в консоли … хотелось бы чтобы консоль открывалась скрытой или вообще без неё в background».)

## Root cause (proven by startup.log)

The `startup.log` diagnostic added in #47 was decisive. At every *real* login boot the log shows `exe=…\Scripts\python.exe` — the **console** interpreter — even though the `HKCU\…\Run` value points at `pythonw.exe`:

```
06-12 10:22  exe='…\Scripts\python.exe'   ← real login → console
06-13 14:00  exe='…\Scripts\python.exe'   ← real login → console
06-14 22:02  exe='…\Scripts\pythonw.exe'  ← manual launch → no console
```

The pipx / pythoncore venv `pythonw.exe` is a **redirector** that re-execs the console `python.exe` at login. The `pythonw` preference from #46 can't win against that.

## Fix

Route autostart through `wscript.exe //B //Nologo <vbs>`, where the VBScript runs the tray via `WScript.Shell.Run(cmd, 0, False)` — window style `0` = `SW_HIDE`. Only the autostart path uses the VBScript, so running `like-spotify` from a terminal is unchanged.

**Empirically verified on the machine** — same console `python.exe`, same redirector chain:

| Launch (via wscript) | console_hwnd | console_visible |
|---|---|---|
| **style 0 (this fix)** | 8391530 | **False** (hidden) |
| style 1 (login default) | 265298 | **True** (the bug) |

`SW_HIDE` forwards through the redirector to the grandchild interpreter, so even when the redirector picks the console interpreter, no window shows.

Also adds `console_hwnd` / `console_visible` to the launch log so the fix is **self-verifying** on the next real boot.

## Tests

3 new unit tests (VBScript emission + quote escaping, wscript routing, frozen-exe bypass). Full suite: **169 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)