### PR TITLE
feat(android): standardize logs with action type, target id, result, HTTP code

### DIFF
--- a/android/app/src/main/kotlin/com/osasuwu/like_spotify/AppConstants.kt
+++ b/android/app/src/main/kotlin/com/osasuwu/like_spotify/AppConstants.kt
@@ -42,6 +42,10 @@ object AppConstants {
     const val EXTRA_EVENT = "event"
     const val EXTRA_LOG = "log"
     const val EXTRA_ACTIVE = "active"
+    const val EXTRA_LOG_ACTION_TYPE = "log_action_type"
+    const val EXTRA_LOG_TARGET_ID = "log_target_id"
+    const val EXTRA_LOG_RESULT = "log_result"
+    const val EXTRA_LOG_HTTP_CODE = "log_http_code"
 
     const val CHANNEL_SERVICE = "like_spotify_mobile_app/service"
     const val CHANNEL_EVENTS = "like_spotify_mobile_app/events"

--- a/android/app/src/main/kotlin/com/osasuwu/like_spotify/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/osasuwu/like_spotify/MainActivity.kt
@@ -216,7 +216,14 @@ class MainActivity : FlutterActivity(), EventChannel.StreamHandler {
 
 					AppConstants.ACTION_LOG_EVENT -> {
 						val value = intent.getStringExtra(AppConstants.EXTRA_LOG) ?: return
-						eventSink?.success(mapOf("type" to "log", "value" to value))
+						val payload = mutableMapOf<String, Any?>("type" to "log", "value" to value)
+						intent.getStringExtra(AppConstants.EXTRA_LOG_ACTION_TYPE)?.let { payload["actionType"] = it }
+						intent.getStringExtra(AppConstants.EXTRA_LOG_TARGET_ID)?.let { payload["targetId"] = it }
+						intent.getStringExtra(AppConstants.EXTRA_LOG_RESULT)?.let { payload["result"] = it }
+						if (intent.hasExtra(AppConstants.EXTRA_LOG_HTTP_CODE)) {
+							payload["httpCode"] = intent.getIntExtra(AppConstants.EXTRA_LOG_HTTP_CODE, 0)
+						}
+						eventSink?.success(payload)
 					}
 
 					AppConstants.ACTION_SERVICE_STATE -> {

--- a/android/app/src/main/kotlin/com/osasuwu/like_spotify/MediaButtonForegroundService.kt
+++ b/android/app/src/main/kotlin/com/osasuwu/like_spotify/MediaButtonForegroundService.kt
@@ -132,8 +132,11 @@ class MediaButtonForegroundService : Service() {
         return raw.split(',').map { it.trim() }.filter { it.isNotEmpty() }
     }
 
-    private fun log(message: String) {
-        val intent = Intent(AppConstants.ACTION_LOG_EVENT).putExtra(AppConstants.EXTRA_LOG, message)
+    private fun log(message: String, actionType: String = "media_event", result: String = "info") {
+        val intent = Intent(AppConstants.ACTION_LOG_EVENT)
+            .putExtra(AppConstants.EXTRA_LOG, message)
+            .putExtra(AppConstants.EXTRA_LOG_ACTION_TYPE, actionType)
+            .putExtra(AppConstants.EXTRA_LOG_RESULT, result)
         LocalBroadcastManager.getInstance(this).sendBroadcast(intent)
     }
 

--- a/android/app/src/main/kotlin/com/osasuwu/like_spotify/PlaybackNotificationListenerService.kt
+++ b/android/app/src/main/kotlin/com/osasuwu/like_spotify/PlaybackNotificationListenerService.kt
@@ -114,9 +114,11 @@ class PlaybackNotificationListenerService : NotificationListenerService() {
         }
     }
 
-    private fun log(message: String) {
+    private fun log(message: String, actionType: String = "notification_listener", result: String = "info") {
         val intent = android.content.Intent(AppConstants.ACTION_LOG_EVENT)
             .putExtra(AppConstants.EXTRA_LOG, message)
+            .putExtra(AppConstants.EXTRA_LOG_ACTION_TYPE, actionType)
+            .putExtra(AppConstants.EXTRA_LOG_RESULT, result)
         androidx.localbroadcastmanager.content.LocalBroadcastManager
             .getInstance(this)
             .sendBroadcast(intent)

--- a/android/app/src/main/kotlin/com/osasuwu/like_spotify/SpotifyLikeWorker.kt
+++ b/android/app/src/main/kotlin/com/osasuwu/like_spotify/SpotifyLikeWorker.kt
@@ -39,7 +39,7 @@ class SpotifyLikeWorker(
         val clientId = prefs.getString(AppConstants.KEY_SPOTIFY_CLIENT_ID, null)
 
         if (accessToken.isNullOrBlank()) {
-            log("Like skipped: Spotify access token missing")
+            log("Like skipped: Spotify access token missing", actionType = "like_track", result = "failure")
             playFeedbackTone(success = false)
             return Result.success()
         }
@@ -79,7 +79,7 @@ class SpotifyLikeWorker(
         }
 
         if (track == null) {
-            log("Like skipped: no currently playing track")
+            log("Like skipped: no currently playing track", actionType = "like_track", result = "failure")
             playFeedbackTone(success = false)
             return Result.success()
         }
@@ -91,13 +91,19 @@ class SpotifyLikeWorker(
         }
 
         // Like the track
-        val liked = likeTrack(track.id, token)
-        playFeedbackTone(success = liked)
-        if (!liked) {
-            log("Like failed for track: ${track.id}")
+        val likeResult = likeTrack(track.id, token)
+        playFeedbackTone(success = likeResult.success)
+        if (!likeResult.success) {
+            log(
+                "Like failed for track: ${track.id}",
+                actionType = "like_track",
+                targetId = track.id,
+                result = "failure",
+                httpCode = likeResult.statusCode
+            )
             return Result.success()
         }
-        log("Liked track: ${track.id}")
+        log("Liked track: ${track.id}", actionType = "like_track", targetId = track.id, result = "success", httpCode = likeResult.statusCode)
 
         runRulePipeline(prefs, token, track)
 
@@ -110,10 +116,34 @@ class SpotifyLikeWorker(
         if (ruleConfig.archiveRemoveEnabled) {
             runCatching {
                 val archiveId = findPlaylistByName(prefs, ruleConfig.archivePlaylistName, token)
-                if (archiveId != null && removeTrackFromPlaylist(archiveId, track.uri, token)) {
-                    log("Removed from archive playlist: ${ruleConfig.archivePlaylistName}")
+                if (archiveId != null) {
+                    val result = removeTrackFromPlaylist(archiveId, track.uri, token)
+                    if (result.success) {
+                        log(
+                            "Removed from archive playlist: ${ruleConfig.archivePlaylistName}",
+                            actionType = "archive_remove",
+                            targetId = track.id,
+                            result = "success",
+                            httpCode = result.statusCode
+                        )
+                    } else {
+                        log(
+                            "Archive removal failed",
+                            actionType = "archive_remove",
+                            targetId = track.id,
+                            result = "failure",
+                            httpCode = result.statusCode
+                        )
+                    }
                 }
-            }.onFailure { log("Archive removal failed: ${it.message}") }
+            }.onFailure {
+                log(
+                    "Archive removal failed: ${it.message}",
+                    actionType = "archive_remove",
+                    targetId = track.id,
+                    result = "failure"
+                )
+            }
         }
 
         val trackCount = runCatching { incrementTrackLikeCount(prefs, track.id) }
@@ -121,20 +151,66 @@ class SpotifyLikeWorker(
         if (ruleConfig.bestOfEnabled && trackCount == ruleConfig.bestOfThreshold) {
             runCatching {
                 val bestOfId = ensurePlaylist(prefs, ruleConfig.bestOfPlaylistName, token)
-                if (bestOfId != null && addTrackToPlaylist(bestOfId, track.uri, token)) {
-                    log("Added to best-of playlist: ${ruleConfig.bestOfPlaylistName}")
+                if (bestOfId != null) {
+                    val result = addTrackToPlaylist(bestOfId, track.uri, token)
+                    if (result.success) {
+                        log(
+                            "Added to best-of playlist: ${ruleConfig.bestOfPlaylistName}",
+                            actionType = "best_of_add",
+                            targetId = track.id,
+                            result = "success",
+                            httpCode = result.statusCode
+                        )
+                    } else {
+                        log(
+                            "Best-of promotion failed",
+                            actionType = "best_of_add",
+                            targetId = track.id,
+                            result = "failure",
+                            httpCode = result.statusCode
+                        )
+                    }
                 }
-            }.onFailure { log("Best-of promotion failed: ${it.message}") }
+            }.onFailure {
+                log(
+                    "Best-of promotion failed: ${it.message}",
+                    actionType = "best_of_add",
+                    targetId = track.id,
+                    result = "failure"
+                )
+            }
         }
 
         val artistId = track.artistId ?: return
         val artistCount = incrementLocalCount(prefs, AppConstants.KEY_ARTIST_LIKE_COUNTS, artistId)
         if (ruleConfig.followArtistEnabled && artistCount == ruleConfig.followArtistThreshold) {
             runCatching {
-                if (followArtist(artistId, token)) {
-                    log("Auto-followed artist: $artistId")
+                val result = followArtist(artistId, token)
+                if (result.success) {
+                    log(
+                        "Auto-followed artist: $artistId",
+                        actionType = "follow_artist",
+                        targetId = artistId,
+                        result = "success",
+                        httpCode = result.statusCode
+                    )
+                } else {
+                    log(
+                        "Follow artist failed",
+                        actionType = "follow_artist",
+                        targetId = artistId,
+                        result = "failure",
+                        httpCode = result.statusCode
+                    )
                 }
-            }.onFailure { log("Follow artist failed: ${it.message}") }
+            }.onFailure {
+                log(
+                    "Follow artist failed: ${it.message}",
+                    actionType = "follow_artist",
+                    targetId = artistId,
+                    result = "failure"
+                )
+            }
         }
     }
 
@@ -305,23 +381,26 @@ class SpotifyLikeWorker(
         return id
     }
 
-    private fun addTrackToPlaylist(playlistId: String, trackUri: String, token: String): Boolean {
+    private fun addTrackToPlaylist(playlistId: String, trackUri: String, token: String): ApiResult {
         val body = JSONObject().put("uris", JSONArray().put(trackUri)).toString()
         val connection = apiWithBody("https://api.spotify.com/v1/playlists/$playlistId/tracks", token, "POST", body)
-        return connection.responseCode in 200..299
+        val code = connection.responseCode
+        return ApiResult(code in 200..299, code)
     }
 
-    private fun removeTrackFromPlaylist(playlistId: String, trackUri: String, token: String): Boolean {
+    private fun removeTrackFromPlaylist(playlistId: String, trackUri: String, token: String): ApiResult {
         val track = JSONObject().put("uri", trackUri)
         val body = JSONObject().put("tracks", JSONArray().put(track)).toString()
         val connection = apiWithBody("https://api.spotify.com/v1/playlists/$playlistId/tracks", token, "DELETE", body)
-        return connection.responseCode in 200..299
+        val code = connection.responseCode
+        return ApiResult(code in 200..299, code)
     }
 
-    private fun followArtist(artistId: String, token: String): Boolean {
+    private fun followArtist(artistId: String, token: String): ApiResult {
         val encoded = URLEncoder.encode(artistId, Charsets.UTF_8.name())
         val connection = api("https://api.spotify.com/v1/me/following?type=artist&ids=$encoded", token, "PUT")
-        return connection.responseCode in 200..299
+        val code = connection.responseCode
+        return ApiResult(code in 200..299, code)
     }
 
     // ---- Core like + track lookup -------------------------------------------------
@@ -340,11 +419,12 @@ class SpotifyLikeWorker(
         return CurrentTrack(id = id, uri = uri, artistId = artistId)
     }
 
-    private fun likeTrack(trackId: String, token: String?): Boolean {
-        if (token.isNullOrBlank()) return false
+    private fun likeTrack(trackId: String, token: String?): ApiResult {
+        if (token.isNullOrBlank()) return ApiResult(false, 0)
         val encodedTrackId = URLEncoder.encode(trackId, Charsets.UTF_8.name())
         val connection = api("https://api.spotify.com/v1/me/tracks?ids=$encodedTrackId", token, "PUT")
-        return connection.responseCode in 200..299
+        val code = connection.responseCode
+        return ApiResult(code in 200..299, code)
     }
 
     private fun refreshAccessToken(refreshToken: String, clientId: String): RefreshedToken? {
@@ -411,13 +491,25 @@ class SpotifyLikeWorker(
         FeedbackPlayer.play(applicationContext, success)
     }
 
-    private fun log(message: String) {
+    private fun log(
+        message: String,
+        actionType: String = "native",
+        targetId: String? = null,
+        result: String = "info",
+        httpCode: Int? = null
+    ) {
         val intent = android.content.Intent(AppConstants.ACTION_LOG_EVENT)
             .putExtra(AppConstants.EXTRA_LOG, message)
+            .putExtra(AppConstants.EXTRA_LOG_ACTION_TYPE, actionType)
+            .putExtra(AppConstants.EXTRA_LOG_RESULT, result)
+        if (targetId != null) intent.putExtra(AppConstants.EXTRA_LOG_TARGET_ID, targetId)
+        if (httpCode != null) intent.putExtra(AppConstants.EXTRA_LOG_HTTP_CODE, httpCode)
         androidx.localbroadcastmanager.content.LocalBroadcastManager
             .getInstance(applicationContext)
             .sendBroadcast(intent)
     }
+
+    private data class ApiResult(val success: Boolean, val statusCode: Int)
 
     private data class CurrentTrack(
         val id: String,

--- a/lib/data/settings/shared_prefs_settings_repository.dart
+++ b/lib/data/settings/shared_prefs_settings_repository.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../core/app_constants.dart';
+import '../../domain/entities/app_log.dart';
 import '../../domain/entities/pending_like.dart';
 import '../../domain/entities/rule_config.dart';
 import '../../domain/entities/trigger_config.dart';
@@ -83,8 +84,13 @@ class SharedPrefsSettingsRepository implements SettingsRepository {
   }
 
   @override
-  Future<List<String>> loadLogs() async {
+  Future<List<AppLog>> loadLogs() async {
     final prefs = await SharedPreferences.getInstance();
+    final lines = await _loadRawLogLines(prefs);
+    return lines.map(AppLog.fromLine).toList(growable: false);
+  }
+
+  Future<List<String>> _loadRawLogLines(SharedPreferences prefs) async {
     final raw = prefs.getStringList(_keyLogs);
     if (raw != null) {
       return raw;
@@ -97,11 +103,11 @@ class SharedPrefsSettingsRepository implements SettingsRepository {
   }
 
   @override
-  Future<void> appendLog(String message) async {
+  Future<void> appendLog(AppLog log) async {
     final prefs = await SharedPreferences.getInstance();
-    final logs = await loadLogs();
-    logs.insert(0, '[${DateTime.now().toIso8601String()}] $message');
-    final clipped = logs.take(300).toList(growable: false);
+    final lines = await _loadRawLogLines(prefs);
+    lines.insert(0, log.toLine());
+    final clipped = lines.take(300).toList(growable: false);
     await prefs.setStringList(_keyLogs, clipped);
   }
 

--- a/lib/data/spotify/spotify_client.dart
+++ b/lib/data/spotify/spotify_client.dart
@@ -80,7 +80,7 @@ class SpotifyClient {
     ).timeout(_timeout);
 
     if (response.statusCode < 200 || response.statusCode > 299) {
-      throw Exception('Spotify token exchange failed (${response.statusCode})');
+      throw SpotifyApiException(response.statusCode, 'Spotify token exchange failed');
     }
 
     final json = jsonDecode(response.body) as Map<String, dynamic>;
@@ -108,7 +108,7 @@ class SpotifyClient {
     ).timeout(_timeout);
 
     if (response.statusCode < 200 || response.statusCode > 299) {
-      throw Exception('Spotify token refresh failed (${response.statusCode})');
+      throw SpotifyApiException(response.statusCode, 'Spotify token refresh failed');
     }
 
     final json = jsonDecode(response.body) as Map<String, dynamic>;
@@ -130,8 +130,9 @@ class SpotifyClient {
     }
 
     if (response.statusCode < 200 || response.statusCode > 299) {
-      throw Exception(
-        'Spotify current track failed (${response.statusCode}): ${response.body}',
+      throw SpotifyApiException(
+        response.statusCode,
+        'Spotify current track failed: ${response.body}',
       );
     }
 
@@ -150,7 +151,7 @@ class SpotifyClient {
     ).timeout(_timeout);
 
     if (response.statusCode < 200 || response.statusCode > 299) {
-      throw Exception('Spotify like track failed (${response.statusCode})');
+      throw SpotifyApiException(response.statusCode, 'Spotify like track failed');
     }
   }
 
@@ -168,7 +169,7 @@ class SpotifyClient {
     }
 
     if (response.statusCode < 200 || response.statusCode > 299) {
-      throw Exception('Spotify current track failed (${response.statusCode})');
+      throw SpotifyApiException(response.statusCode, 'Spotify current track failed');
     }
 
     final json = jsonDecode(response.body) as Map<String, dynamic>;
@@ -222,7 +223,7 @@ class SpotifyClient {
       headers: <String, String>{'Authorization': 'Bearer $accessToken'},
     ).timeout(_timeout);
     if (response.statusCode < 200 || response.statusCode > 299) {
-      throw Exception('Spotify get playlists failed (${response.statusCode})');
+      throw SpotifyApiException(response.statusCode, 'Spotify get playlists failed');
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
     final items = json['items'] as List<dynamic>? ?? <dynamic>[];
@@ -260,7 +261,7 @@ class SpotifyClient {
       }),
     ).timeout(_timeout);
     if (response.statusCode < 200 || response.statusCode > 299) {
-      throw Exception('Spotify create playlist failed (${response.statusCode})');
+      throw SpotifyApiException(response.statusCode, 'Spotify create playlist failed');
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
     return json['id'] as String;
@@ -281,7 +282,7 @@ class SpotifyClient {
       body: jsonEncode(<String, dynamic>{'uris': trackUris}),
     ).timeout(_timeout);
     if (response.statusCode < 200 || response.statusCode > 299) {
-      throw Exception('Spotify add to playlist failed (${response.statusCode})');
+      throw SpotifyApiException(response.statusCode, 'Spotify add to playlist failed');
     }
   }
 
@@ -303,7 +304,7 @@ class SpotifyClient {
 
     final streamed = await _http.send(request).timeout(_timeout);
     if (streamed.statusCode < 200 || streamed.statusCode > 299) {
-      throw Exception('Spotify remove from playlist failed (${streamed.statusCode})');
+      throw SpotifyApiException(streamed.statusCode, 'Spotify remove from playlist failed');
     }
   }
 
@@ -319,7 +320,7 @@ class SpotifyClient {
       headers: <String, String>{'Authorization': 'Bearer $accessToken'},
     ).timeout(_timeout);
     if (response.statusCode < 200 || response.statusCode > 299) {
-      throw Exception('Spotify follow artists failed (${response.statusCode})');
+      throw SpotifyApiException(response.statusCode, 'Spotify follow artists failed');
     }
   }
 
@@ -334,7 +335,7 @@ class SpotifyClient {
       headers: <String, String>{'Authorization': 'Bearer $accessToken'},
     ).timeout(_timeout);
     if (response.statusCode < 200 || response.statusCode > 299) {
-      throw Exception('Spotify get saved tracks failed (${response.statusCode})');
+      throw SpotifyApiException(response.statusCode, 'Spotify get saved tracks failed');
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
     final items = json['items'] as List<dynamic>? ?? <dynamic>[];
@@ -362,10 +363,20 @@ class SpotifyClient {
   }
 }
 
-/// Thrown when Spotify returns 401, signaling the caller should refresh and retry.
-class SpotifyAuthException implements Exception {
+/// Thrown when a Spotify API call returns a non-2xx response, carrying the
+/// real HTTP status code so callers/logs can surface it instead of just the
+/// message text.
+class SpotifyApiException implements Exception {
+  final int statusCode;
   final String message;
-  SpotifyAuthException(this.message);
+  SpotifyApiException(this.statusCode, this.message);
+  @override
+  String toString() => 'SpotifyApiException($statusCode): $message';
+}
+
+/// Thrown when Spotify returns 401, signaling the caller should refresh and retry.
+class SpotifyAuthException extends SpotifyApiException {
+  SpotifyAuthException(String message) : super(401, message);
   @override
   String toString() => 'SpotifyAuthException: $message';
 }

--- a/lib/data/spotify/spotify_music_service_repository.dart
+++ b/lib/data/spotify/spotify_music_service_repository.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../../domain/entities/app_log.dart';
 import '../../domain/entities/like_result.dart';
 import '../../domain/entities/pending_like.dart';
 import '../../domain/entities/spotify_auth_state.dart';
@@ -276,6 +277,14 @@ class SpotifyMusicServiceRepository implements MusicServiceRepository {
         }
       } catch (e) {
         debugPrint('Archive removal failed: $e');
+        await _settingsRepository.appendLog(AppLog(
+          at: DateTime.now().toUtc(),
+          actionType: 'archive_remove',
+          targetId: trackInfo.trackId,
+          result: LogResult.failure,
+          httpCode: e is SpotifyApiException ? e.statusCode : null,
+          message: 'Archive removal failed: $e',
+        ));
       }
     }
 
@@ -295,6 +304,14 @@ class SpotifyMusicServiceRepository implements MusicServiceRepository {
         }
       } catch (e) {
         debugPrint('Best-of add failed: $e');
+        await _settingsRepository.appendLog(AppLog(
+          at: DateTime.now().toUtc(),
+          actionType: 'best_of_add',
+          targetId: trackInfo.trackId,
+          result: LogResult.failure,
+          httpCode: e is SpotifyApiException ? e.statusCode : null,
+          message: 'Best-of add failed: $e',
+        ));
       }
     }
 
@@ -310,6 +327,14 @@ class SpotifyMusicServiceRepository implements MusicServiceRepository {
           followedArtistNames.add(name);
         } catch (e) {
           debugPrint('Artist follow failed for $artistId: $e');
+          await _settingsRepository.appendLog(AppLog(
+            at: DateTime.now().toUtc(),
+            actionType: 'follow_artist',
+            targetId: artistId,
+            result: LogResult.failure,
+            httpCode: e is SpotifyApiException ? e.statusCode : null,
+            message: 'Artist follow failed for $artistId: $e',
+          ));
         }
       }
     }

--- a/lib/domain/entities/app_log.dart
+++ b/lib/domain/entities/app_log.dart
@@ -1,6 +1,68 @@
+import 'dart:convert';
+
+enum LogResult {
+  success,
+  failure,
+  info;
+
+  static LogResult fromName(String? name) {
+    return LogResult.values.firstWhere(
+      (value) => value.name == name,
+      orElse: () => LogResult.info,
+    );
+  }
+}
+
 class AppLog {
   final DateTime at;
+  final String actionType;
+  final String? targetId;
+  final LogResult result;
+  final int? httpCode;
   final String message;
 
-  const AppLog({required this.at, required this.message});
+  const AppLog({
+    required this.at,
+    this.actionType = 'legacy',
+    this.targetId,
+    this.result = LogResult.info,
+    this.httpCode,
+    required this.message,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'at': at.toIso8601String(),
+      'actionType': actionType,
+      if (targetId != null) 'targetId': targetId,
+      'result': result.name,
+      if (httpCode != null) 'httpCode': httpCode,
+      'message': message,
+    };
+  }
+
+  factory AppLog.fromJson(Map<String, dynamic> json) {
+    return AppLog(
+      at: DateTime.parse(json['at'] as String),
+      actionType: json['actionType'] as String? ?? 'legacy',
+      targetId: json['targetId'] as String?,
+      result: LogResult.fromName(json['result'] as String?),
+      httpCode: json['httpCode'] as int?,
+      message: json['message'] as String? ?? '',
+    );
+  }
+
+  String toLine() => jsonEncode(toJson());
+
+  factory AppLog.fromLine(String line) {
+    try {
+      final decoded = jsonDecode(line);
+      if (decoded is Map<String, dynamic>) {
+        return AppLog.fromJson(decoded);
+      }
+    } catch (_) {
+      // Not JSON — fall through to legacy plain-text handling below.
+    }
+    return AppLog(at: DateTime.now().toUtc(), actionType: 'legacy', message: line);
+  }
 }

--- a/lib/domain/repositories/settings_repository.dart
+++ b/lib/domain/repositories/settings_repository.dart
@@ -1,3 +1,4 @@
+import '../entities/app_log.dart';
 import '../entities/pending_like.dart';
 import '../entities/rule_config.dart';
 import '../entities/trigger_config.dart';
@@ -9,8 +10,8 @@ abstract class SettingsRepository {
   Future<void> saveRuleConfig(RuleConfig config);
   Future<bool> loadServiceEnabled();
   Future<void> saveServiceEnabled(bool enabled);
-  Future<List<String>> loadLogs();
-  Future<void> appendLog(String message);
+  Future<List<AppLog>> loadLogs();
+  Future<void> appendLog(AppLog log);
   Future<void> clearLogs();
   Future<List<PendingLike>> loadPendingLikes();
   Future<void> savePendingLikes(List<PendingLike> likes);

--- a/lib/presentation/screens/logs_screen.dart
+++ b/lib/presentation/screens/logs_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../domain/entities/app_log.dart';
 import '../state/app_providers.dart';
 
 class LogsScreen extends ConsumerWidget {
@@ -28,9 +29,27 @@ class LogsScreen extends ConsumerWidget {
               separatorBuilder: (_, index) => const Divider(height: 1),
               itemBuilder: (context, index) {
                 final log = logs[index];
+                final subtitleParts = <String>[
+                  log.actionType,
+                  if (log.targetId != null) log.targetId!,
+                  if (log.httpCode != null) 'HTTP ${log.httpCode}',
+                ];
                 return ListTile(
                   dense: true,
+                  leading: Icon(
+                    switch (log.result) {
+                      LogResult.success => Icons.check_circle_outline,
+                      LogResult.failure => Icons.error_outline,
+                      LogResult.info => Icons.info_outline,
+                    },
+                    color: switch (log.result) {
+                      LogResult.success => Colors.green,
+                      LogResult.failure => Colors.red,
+                      LogResult.info => Colors.grey,
+                    },
+                  ),
                   title: Text(log.message),
+                  subtitle: Text(subtitleParts.join(' · ')),
                 );
               },
             ),

--- a/lib/presentation/state/app_controller.dart
+++ b/lib/presentation/state/app_controller.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import '../../core/app_constants.dart';
+import '../../data/spotify/spotify_client.dart';
 import '../../data/spotify/spotify_music_service_repository.dart';
 import '../../domain/entities/app_log.dart';
 import '../../domain/entities/pending_like.dart';
@@ -85,9 +86,7 @@ class AppController extends StateNotifier<AppState> {
         isMiui: isMiui,
         spotifyInstalled: spotifyInstalled,
         ruleConfig: ruleConfig,
-        logs: logLines
-            .map((line) => AppLog(at: DateTime.now().toUtc(), message: line))
-            .toList(growable: false),
+        logs: logLines,
       );
 
       // Load pending likes count
@@ -120,7 +119,11 @@ class AppController extends StateNotifier<AppState> {
       }
       await _settingsRepository.saveServiceEnabled(enabled);
       state = state.copyWith(serviceEnabled: enabled, clearError: true);
-      await addLog('Service ${enabled ? 'enabled' : 'disabled'}');
+      await addLog(
+        actionType: 'service_toggle',
+        result: LogResult.success,
+        message: 'Service ${enabled ? 'enabled' : 'disabled'}',
+      );
     } catch (error) {
       state = state.copyWith(lastError: error.toString());
     }
@@ -129,28 +132,52 @@ class AppController extends StateNotifier<AppState> {
   Future<void> ensureRuntimePermissions() async {
     final notificationStatus = await Permission.notification.status;
     if (notificationStatus.isGranted) {
-      await addLog('Notification permission already granted');
+      await addLog(
+        actionType: 'permission_notification',
+        result: LogResult.info,
+        message: 'Notification permission already granted',
+      );
       return;
     }
 
     final requested = await Permission.notification.request();
     if (requested.isGranted) {
-      await addLog('Notification permission granted');
+      await addLog(
+        actionType: 'permission_notification',
+        result: LogResult.success,
+        message: 'Notification permission granted',
+      );
     } else if (requested.isPermanentlyDenied) {
-      await addLog('Notification permission permanently denied; opening app settings');
+      await addLog(
+        actionType: 'permission_notification',
+        result: LogResult.failure,
+        message: 'Notification permission permanently denied; opening app settings',
+      );
       await _platformServiceRepository.openNotificationSettings();
     } else {
-      await addLog('Notification permission denied');
+      await addLog(
+        actionType: 'permission_notification',
+        result: LogResult.failure,
+        message: 'Notification permission denied',
+      );
     }
   }
 
   Future<void> connectSpotify() async {
     try {
       if (!state.spotifyInstalled) {
-        await addLog('Spotify app is not installed.');
+        await addLog(
+          actionType: 'spotify_connect',
+          result: LogResult.failure,
+          message: 'Spotify app is not installed.',
+        );
       }
       await _musicServiceRepository.connectSpotify();
-      await addLog('Waiting for Spotify OAuth callback...');
+      await addLog(
+        actionType: 'spotify_connect',
+        result: LogResult.info,
+        message: 'Waiting for Spotify OAuth callback...',
+      );
     } catch (error) {
       state = state.copyWith(lastError: error.toString());
     }
@@ -162,14 +189,22 @@ class AppController extends StateNotifier<AppState> {
       authState: const SpotifyAuthState.disconnected(),
       clearError: true,
     );
-    await addLog('Spotify disconnected');
+    await addLog(
+      actionType: 'spotify_disconnect',
+      result: LogResult.success,
+      message: 'Spotify disconnected',
+    );
   }
 
   Future<void> saveTriggerConfig(TriggerConfig config) async {
     await _settingsRepository.saveTriggerConfig(config);
     await _platformServiceRepository.updateTriggerConfig(config);
     state = state.copyWith(triggerConfig: config, clearError: true);
-    await addLog('Trigger config updated to ${config.pattern} (${config.windowMs}ms)');
+    await addLog(
+      actionType: 'trigger_config',
+      result: LogResult.success,
+      message: 'Trigger config updated to ${config.pattern} (${config.windowMs}ms)',
+    );
   }
 
   Future<void> saveRuleConfig(RuleConfig config) async {
@@ -185,7 +220,11 @@ class AppController extends StateNotifier<AppState> {
     await _settingsRepository.saveRuleConfig(normalized);
     await _platformServiceRepository.updateRuleConfig(normalized);
     state = state.copyWith(ruleConfig: normalized, clearError: true);
-    await addLog('Rule config updated');
+    await addLog(
+      actionType: 'rule_config',
+      result: LogResult.success,
+      message: 'Rule config updated',
+    );
   }
 
   Future<void> requestBatteryOptimizationExemption() async {
@@ -207,14 +246,22 @@ class AppController extends StateNotifier<AppState> {
 
   Future<void> openNotificationListenerSettings() async {
     await _platformServiceRepository.openNotificationListenerSettings();
-    await addLog('Opened notification access settings; enable access and tap refresh');
+    await addLog(
+      actionType: 'notification_listener',
+      result: LogResult.info,
+      message: 'Opened notification access settings; enable access and tap refresh',
+    );
   }
 
   Future<void> refreshNotificationListenerStatus() async {
     final enabled = await _platformServiceRepository.isNotificationListenerEnabled();
     state = state.copyWith(notificationListenerEnabled: enabled);
     if (!enabled) {
-      await addLog('Notification access is disabled; playback-state fallback is unavailable');
+      await addLog(
+        actionType: 'notification_listener',
+        result: LogResult.failure,
+        message: 'Notification access is disabled; playback-state fallback is unavailable',
+      );
     }
   }
 
@@ -228,19 +275,41 @@ class AppController extends StateNotifier<AppState> {
       state = state.copyWith(clearError: true, clearLikeResult: true, liking: true);
       final result = await _musicServiceRepository.likeCurrentTrack();
       state = state.copyWith(lastLikeResult: result, liking: false);
-      await addLog('Liked: ${result.trackName} (x${result.trackLikeCount})');
+      await addLog(
+        actionType: 'like_track',
+        targetId: result.trackName,
+        result: LogResult.success,
+        message: 'Liked: ${result.trackName} (x${result.trackLikeCount})',
+      );
       if (result.removedFromArchive) {
-        await addLog('Removed from archive playlist');
+        await addLog(
+          actionType: 'archive_remove',
+          result: LogResult.success,
+          message: 'Removed from archive playlist',
+        );
       }
       if (result.addedToBestOf) {
-        await addLog('Added to best-of playlist');
+        await addLog(
+          actionType: 'best_of_add',
+          result: LogResult.success,
+          message: 'Added to best-of playlist',
+        );
       }
       if (result.followedArtistNames.isNotEmpty) {
-        await addLog('Auto-followed: ${result.followedArtistNames.join(", ")}');
+        await addLog(
+          actionType: 'follow_artist',
+          result: LogResult.success,
+          message: 'Auto-followed: ${result.followedArtistNames.join(", ")}',
+        );
       }
     } catch (error) {
       state = state.copyWith(lastError: error.toString(), liking: false);
-      await addLog('Like command failed: $error');
+      await addLog(
+        actionType: 'like_track',
+        result: LogResult.failure,
+        httpCode: error is SpotifyApiException ? error.statusCode : null,
+        message: 'Like command failed: $error',
+      );
       // Try to queue for offline retry — we need the track info.
       // If we can still reach Spotify to get current track, queue it.
       await _tryQueueCurrentTrack();
@@ -268,10 +337,18 @@ class AppController extends StateNotifier<AppState> {
     final pending = await _settingsRepository.loadPendingLikes();
     if (pending.isEmpty) return;
 
-    await addLog('Online — processing ${pending.length} queued like(s)...');
+    await addLog(
+      actionType: 'process_pending',
+      result: LogResult.info,
+      message: 'Online — processing ${pending.length} queued like(s)...',
+    );
     final processed = await _musicServiceRepository.processPendingLikes(pending);
     if (processed > 0) {
-      await addLog('Processed $processed queued like(s)');
+      await addLog(
+        actionType: 'process_pending',
+        result: LogResult.success,
+        message: 'Processed $processed queued like(s)',
+      );
       final remaining = await _settingsRepository.loadPendingLikes();
       state = state.copyWith(pendingLikesCount: remaining.length);
     }
@@ -289,7 +366,12 @@ class AppController extends StateNotifier<AppState> {
     await _settingsRepository.addPendingLike(pending);
     final count = (await _settingsRepository.loadPendingLikes()).length;
     state = state.copyWith(pendingLikesCount: count);
-    await addLog('Queued for later: ${trackInfo.trackName}');
+    await addLog(
+      actionType: 'queue_pending',
+      targetId: trackInfo.trackId,
+      result: LogResult.info,
+      message: 'Queued for later: ${trackInfo.trackName}',
+    );
   }
 
   Future<void> clearLogs() async {
@@ -297,14 +379,23 @@ class AppController extends StateNotifier<AppState> {
     state = state.copyWith(logs: <AppLog>[]);
   }
 
-  Future<void> addLog(String message) async {
-    await _settingsRepository.appendLog(message);
+  Future<void> addLog({
+    required String actionType,
+    String? targetId,
+    LogResult result = LogResult.info,
+    int? httpCode,
+    required String message,
+  }) async {
+    await _settingsRepository.appendLog(AppLog(
+      at: DateTime.now().toUtc(),
+      actionType: actionType,
+      targetId: targetId,
+      result: result,
+      httpCode: httpCode,
+      message: message,
+    ));
     final logs = await _settingsRepository.loadLogs();
-    state = state.copyWith(
-      logs: logs
-          .map((line) => AppLog(at: DateTime.now().toUtc(), message: line))
-          .toList(growable: false),
-    );
+    state = state.copyWith(logs: logs);
   }
 
   Future<void> _onIncomingLink(Uri uri) async {
@@ -315,7 +406,11 @@ class AppController extends StateNotifier<AppState> {
         if (handled) {
           final auth = await repository.getAuthState();
           state = state.copyWith(authState: auth, clearError: true);
-          await addLog('Spotify connected successfully');
+          await addLog(
+            actionType: 'oauth_callback',
+            result: LogResult.success,
+            message: 'Spotify connected successfully',
+          );
         }
       }
     } catch (error) {
@@ -333,12 +428,22 @@ class AppController extends StateNotifier<AppState> {
     }
 
     if (type == 'log' && value is String) {
-      unawaited(addLog('[native] $value'));
+      unawaited(addLog(
+        actionType: event['actionType'] as String? ?? 'native',
+        targetId: event['targetId'] as String?,
+        result: LogResult.fromName(event['result'] as String?),
+        httpCode: event['httpCode'] as int?,
+        message: value,
+      ));
       return;
     }
 
     if (type == 'media' && value is String) {
-      unawaited(addLog('Media event: $value'));
+      unawaited(addLog(
+        actionType: 'media_event',
+        result: LogResult.info,
+        message: 'Media event: $value',
+      ));
       return;
     }
 
@@ -356,20 +461,42 @@ class AppController extends StateNotifier<AppState> {
 
       await _platformServiceRepository.playFeedbackTone(success: result.success);
 
-      await addLog('Liked: ${result.trackName} (x${result.trackLikeCount})');
+      await addLog(
+        actionType: 'like_track',
+        targetId: result.trackName,
+        result: LogResult.success,
+        message: 'Liked: ${result.trackName} (x${result.trackLikeCount})',
+      );
       if (result.removedFromArchive) {
-        await addLog('Removed from archive playlist');
+        await addLog(
+          actionType: 'archive_remove',
+          result: LogResult.success,
+          message: 'Removed from archive playlist',
+        );
       }
       if (result.addedToBestOf) {
-        await addLog('Added to best-of playlist');
+        await addLog(
+          actionType: 'best_of_add',
+          result: LogResult.success,
+          message: 'Added to best-of playlist',
+        );
       }
       if (result.followedArtistNames.isNotEmpty) {
-        await addLog('Auto-followed: ${result.followedArtistNames.join(", ")}');
+        await addLog(
+          actionType: 'follow_artist',
+          result: LogResult.success,
+          message: 'Auto-followed: ${result.followedArtistNames.join(", ")}',
+        );
       }
     } catch (error) {
       state = state.copyWith(lastError: error.toString(), liking: false);
       await _platformServiceRepository.playFeedbackTone(success: false);
-      await addLog('Like from trigger failed: $error');
+      await addLog(
+        actionType: 'like_track',
+        result: LogResult.failure,
+        httpCode: error is SpotifyApiException ? error.statusCode : null,
+        message: 'Like from trigger failed: $error',
+      );
       await _tryQueueCurrentTrack();
     }
   }


### PR DESCRIPTION
## Summary
- Adds structured fields to `AppLog` (actionType, targetId, result, httpCode) with JSON-line persistence, backward compatible with legacy plain-text log entries
- Adds `SpotifyApiException(statusCode, message)` so real HTTP status codes surface instead of being embedded only in exception message text; `SpotifyAuthException` now extends it
- Threads structured fields through every Dart log call site (~24) and the previously-silent archive-remove/best-of/follow-artist failure paths in `SpotifyMusicServiceRepository`
- Mirrors the same structure on the Kotlin side: new `AppConstants` extras, `MainActivity`'s event bridge forwards them, and `SpotifyLikeWorker`/`MediaButtonForegroundService`/`PlaybackNotificationListenerService`'s `log()` helpers gain `actionType`/`targetId`/`result`/`httpCode` params (worker's playlist/follow calls now return an `ApiResult` carrying the real status code instead of a bare `Boolean`)
- Updates the logs screen to show actionType/targetId/HTTP code alongside the message, with a result icon

Closes #15

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 153 tests pass
- [ ] CI (test, pytest, review checks)