### PR TITLE
feat(android): add diagnostics export bundle

### DIFF
--- a/lib/data/likes/shared_prefs_like_count_repository.dart
+++ b/lib/data/likes/shared_prefs_like_count_repository.dart
@@ -24,6 +24,12 @@ class SharedPrefsLikeCountRepository implements LikeCountRepository {
   Future<int> getArtistLikeCount(String artistId) =>
       _getCount(_keyArtistCounts, artistId);
 
+  @override
+  Future<Map<String, int>> loadAllTrackLikeCounts() => _loadMap(_keyTrackCounts);
+
+  @override
+  Future<Map<String, int>> loadAllArtistLikeCounts() => _loadMap(_keyArtistCounts);
+
   Future<int> _increment(String key, String itemId) async {
     final map = await _loadMap(key);
     final next = (map[itemId] ?? 0) + 1;

--- a/lib/data/likes/supabase_like_count_repository.dart
+++ b/lib/data/likes/supabase_like_count_repository.dart
@@ -46,6 +46,14 @@ class SupabaseLikeCountRepository implements LikeCountRepository {
   Future<int> getArtistLikeCount(String artistId) =>
       _local.getArtistLikeCount(artistId);
 
+  @override
+  Future<Map<String, int>> loadAllTrackLikeCounts() =>
+      _local.loadAllTrackLikeCounts();
+
+  @override
+  Future<Map<String, int>> loadAllArtistLikeCounts() =>
+      _local.loadAllArtistLikeCounts();
+
   Future<int?> _supabaseIncrement(String userId, String trackId) async {
     try {
       final response = await http.post(

--- a/lib/data/spotify/spotify_music_service_repository.dart
+++ b/lib/data/spotify/spotify_music_service_repository.dart
@@ -372,6 +372,14 @@ class SpotifyMusicServiceRepository implements MusicServiceRepository {
     return processed;
   }
 
+  @override
+  Future<Map<String, Map<String, int>>> loadAllLikeCounts() async {
+    return <String, Map<String, int>>{
+      'tracks': await _likeCountRepository.loadAllTrackLikeCounts(),
+      'artists': await _likeCountRepository.loadAllArtistLikeCounts(),
+    };
+  }
+
   /// Expose playlist service's cached user ID for Supabase like counting.
   String? get cachedUserId => _playlistService.cachedUserId;
 }

--- a/lib/domain/repositories/like_count_repository.dart
+++ b/lib/domain/repositories/like_count_repository.dart
@@ -3,4 +3,6 @@ abstract class LikeCountRepository {
   Future<int> getTrackLikeCount(String trackId);
   Future<int> incrementArtistLikeCount(String artistId);
   Future<int> getArtistLikeCount(String artistId);
+  Future<Map<String, int>> loadAllTrackLikeCounts();
+  Future<Map<String, int>> loadAllArtistLikeCounts();
 }

--- a/lib/domain/repositories/music_service_repository.dart
+++ b/lib/domain/repositories/music_service_repository.dart
@@ -11,4 +11,5 @@ abstract class MusicServiceRepository {
   Future<LikeResult> likeTrack(TrackInfo trackInfo);
   Future<void> refreshIfNeeded();
   Future<int> processPendingLikes(List<PendingLike> pending);
+  Future<Map<String, Map<String, int>>> loadAllLikeCounts();
 }

--- a/lib/presentation/screens/logs_screen.dart
+++ b/lib/presentation/screens/logs_screen.dart
@@ -17,7 +17,13 @@ class LogsScreen extends ConsumerWidget {
         title: const Text('Logs / debug'),
         actions: <Widget>[
           IconButton(
+            onPressed: controller.exportDiagnostics,
+            tooltip: 'Export diagnostics',
+            icon: const Icon(Icons.ios_share),
+          ),
+          IconButton(
             onPressed: controller.clearLogs,
+            tooltip: 'Clear logs',
             icon: const Icon(Icons.delete_outline),
           ),
         ],

--- a/lib/presentation/state/app_controller.dart
+++ b/lib/presentation/state/app_controller.dart
@@ -1,9 +1,13 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:app_links/app_links.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:share_plus/share_plus.dart';
 
 import '../../core/app_constants.dart';
 import '../../data/spotify/spotify_client.dart';
@@ -377,6 +381,66 @@ class AppController extends StateNotifier<AppState> {
   Future<void> clearLogs() async {
     await _settingsRepository.clearLogs();
     state = state.copyWith(logs: <AppLog>[]);
+  }
+
+  Future<void> exportDiagnostics() async {
+    try {
+      final packageInfo = await PackageInfo.fromPlatform();
+      final androidInfo = await DeviceInfoPlugin().androidInfo;
+      final likeCounts = await _musicServiceRepository.loadAllLikeCounts();
+
+      final bundle = <String, dynamic>{
+        'exportedAt': DateTime.now().toUtc().toIso8601String(),
+        'app': <String, dynamic>{
+          'packageName': packageInfo.packageName,
+          'version': packageInfo.version,
+          'buildNumber': packageInfo.buildNumber,
+        },
+        'device': <String, dynamic>{
+          'manufacturer': androidInfo.manufacturer,
+          'model': androidInfo.model,
+          'androidRelease': androidInfo.version.release,
+          'sdkInt': androidInfo.version.sdkInt,
+        },
+        'service': <String, dynamic>{
+          'enabled': state.serviceEnabled,
+          'isMiui': state.isMiui,
+          'batteryOptimized': state.batteryOptimized,
+          'notificationListenerEnabled': state.notificationListenerEnabled,
+          'spotifyInstalled': state.spotifyInstalled,
+        },
+        // Only non-secret auth fields — never export accessToken/refreshToken.
+        'auth': <String, dynamic>{
+          'connected': state.authState.connected,
+          'isExpired': state.authState.isExpired,
+        },
+        'triggerConfig': <String, dynamic>{
+          'pattern': state.triggerConfig.pattern,
+          'windowMs': state.triggerConfig.windowMs,
+          'debounceMs': state.triggerConfig.debounceMs,
+        },
+        'ruleConfig': state.ruleConfig.toJson(),
+        'likeCounts': likeCounts,
+        'logs': state.logs.map((log) => log.toJson()).toList(),
+      };
+
+      final jsonText = const JsonEncoder.withIndent('  ').convert(bundle);
+      await SharePlus.instance.share(
+        ShareParams(text: jsonText, subject: 'Like Spotify diagnostics export'),
+      );
+      await addLog(
+        actionType: 'export_diagnostics',
+        result: LogResult.success,
+        message: 'Exported diagnostics bundle (${state.logs.length} log entries)',
+      );
+    } catch (error) {
+      state = state.copyWith(lastError: error.toString());
+      await addLog(
+        actionType: 'export_diagnostics',
+        result: LogResult.failure,
+        message: 'Diagnostics export failed: $error',
+      );
+    }
   }
 
   Future<void> addLog({

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+4"
   crypto:
     dependency: "direct main"
     description:
@@ -161,6 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -352,6 +368,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -544,6 +568,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -733,6 +773,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.5"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   collection: ^1.19.1
   crypto: ^3.0.6
   app_links: ^6.4.1
+  share_plus: ^12.0.2
 
 dev_dependencies:
   flutter_test:

--- a/test/data/likes/shared_prefs_like_count_repository_test.dart
+++ b/test/data/likes/shared_prefs_like_count_repository_test.dart
@@ -70,4 +70,33 @@ void main() {
       expect(await repo.getArtistLikeCount('same-id'), 1);
     });
   });
+
+  group('bulk enumeration', () {
+    test('loadAllTrackLikeCounts returns empty map when nothing stored', () async {
+      expect(await repo.loadAllTrackLikeCounts(), <String, int>{});
+    });
+
+    test('loadAllTrackLikeCounts returns every stored track count', () async {
+      await repo.incrementTrackLikeCount('track-a');
+      await repo.incrementTrackLikeCount('track-a');
+      await repo.incrementTrackLikeCount('track-b');
+
+      expect(await repo.loadAllTrackLikeCounts(), <String, int>{
+        'track-a': 2,
+        'track-b': 1,
+      });
+    });
+
+    test('loadAllArtistLikeCounts returns every stored artist count', () async {
+      await repo.incrementArtistLikeCount('artist-a');
+      await repo.incrementArtistLikeCount('artist-b');
+      await repo.incrementArtistLikeCount('artist-b');
+      await repo.incrementArtistLikeCount('artist-b');
+
+      expect(await repo.loadAllArtistLikeCounts(), <String, int>{
+        'artist-a': 1,
+        'artist-b': 3,
+      });
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Adds `AppController.exportDiagnostics()`, wired to a new export button on the logs screen, which shares an in-app JSON bundle of logs, like counters, and environment metadata (app version, device info, service/permission status, trigger + rule config).
- Adds `loadAllTrackLikeCounts()`/`loadAllArtistLikeCounts()` to `LikeCountRepository` (implemented in both `SharedPrefsLikeCountRepository` and `SupabaseLikeCountRepository`) and `loadAllLikeCounts()` to `MusicServiceRepository`, so the bundle can enumerate all stored counts, not just per-ID lookups.
- Auth section only includes `connected`/`isExpired` — access/refresh tokens are never exported.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 156 passed, including 3 new repository tests for bulk count enumeration

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)