### PR TITLE
test(desktop): add regression tests for TrayFeedback._beep / _synth_tone

### DIFF
--- a/like_spotify/hosts/windows/feedback.py
+++ b/like_spotify/hosts/windows/feedback.py
@@ -12,6 +12,7 @@ import struct
 import threading
 import time
 from array import array
+from collections.abc import Callable
 
 from .. import _common
 
@@ -109,11 +110,30 @@ def _synth_tones(volume: float) -> dict[str, bytes]:
     }
 
 
+def _play_tone(data: bytes) -> None:
+    """Play a synthesized-tone WAV buffer through the default sound device.
+
+    `SND_MEMORY` only, deliberately no `SND_ASYNC`: winsound rejects
+    `SND_MEMORY | SND_ASYNC` outright (buffer lifetime can't be guaranteed
+    for async playback from memory) and raises
+    `RuntimeError: Cannot play asynchronously from memory` — see 78f1e17,
+    which fixed a crash on every beep. `_beep` already runs on its own
+    daemon thread, so synchronous playback here doesn't block the caller.
+    """
+    import winsound
+
+    winsound.PlaySound(data, winsound.SND_MEMORY)
+
+
 class TrayFeedback:
     """Owns the tray icon + flash / beep / balloon feedback."""
 
     def __init__(
-        self, hotkey: str, volume: float = _common.DEFAULT_FEEDBACK_VOLUME
+        self,
+        hotkey: str,
+        volume: float = _common.DEFAULT_FEEDBACK_VOLUME,
+        *,
+        player: Callable[[bytes], None] = _play_tone,
     ) -> None:
         self._hotkey = hotkey
         self._icon_default = _make_heart_icon(_ICON_GREEN)
@@ -121,6 +141,7 @@ class TrayFeedback:
         self._icon_error = _make_heart_icon(_ICON_RED)
         self._icon = None  # set in run()
         self._tones = _synth_tones(volume)
+        self._player = player
 
     def attach(self, icon) -> None:
         self._icon = icon
@@ -148,21 +169,21 @@ class TrayFeedback:
     def _beep(self, success: bool, kind: str) -> None:
         """Audible confirmation through the default sound device.
 
-        Plays a synthesized tone (`_synth_tone`, see module docstring) via
-        `PlaySound(..., SND_MEMORY)` rather than `MessageBeep` or `Beep` —
-        both proved unreliable/silent on real hardware. Distinct tones per
-        outcome so like / remove / error are distinguishable without
-        looking at the tray.
+        Plays a synthesized tone (`_synth_tone`, see module docstring)
+        through `self._player` (`_play_tone` by default) rather than
+        `MessageBeep` or `Beep` — both proved unreliable/silent on real
+        hardware. Distinct tones per outcome so like / remove / error are
+        distinguishable without looking at the tray. `player` is an
+        injectable seam so tests can capture playback without touching
+        `winsound`/real audio.
         """
-        import winsound
-
         if not success:
             tone = self._tones["error"]
         elif kind == "remove":
             tone = self._tones["remove"]
         else:
             tone = self._tones["like"]
-        winsound.PlaySound(tone, winsound.SND_MEMORY)
+        self._player(tone)
 
     @property
     def default_icon(self):

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,121 @@
+"""Regression tests for TrayFeedback._beep / _synth_tone (feedback.py).
+
+Slice: #56. `hosts/windows.py`'s split in #55 isolated `TrayFeedback` into
+its own module but left it untested — exactly where the SND_ASYNC-from-
+memory crash (78f1e17) lived. `_play_tone` is an injectable seam
+(`TrayFeedback(..., player=...)`) so these tests never touch a real sound
+device.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from like_spotify.hosts.windows import feedback
+
+
+# ── _synth_tone / _synth_tones ─────────────────────────────────────────
+
+
+def test_synth_tone_produces_a_valid_wav_header() -> None:
+    data = feedback._synth_tone([(440, 50)], volume=1.0)
+    assert data[:4] == b"RIFF"
+    assert data[8:12] == b"WAVE"
+    assert data[12:16] == b"fmt "
+
+
+def test_synth_tone_volume_scales_peak_amplitude() -> None:
+    loud = feedback._synth_tone([(440, 50)], volume=1.0)
+    quiet = feedback._synth_tone([(440, 50)], volume=0.1)
+    # Volume doesn't change duration, only amplitude.
+    assert len(loud) == len(quiet)
+    assert max(loud) >= max(quiet)
+
+
+def test_synth_tones_returns_distinct_like_remove_error() -> None:
+    tones = feedback._synth_tones(volume=1.0)
+    assert set(tones) == {"like", "remove", "error"}
+    assert tones["like"] != tones["remove"]
+    assert tones["remove"] != tones["error"]
+
+
+# ── TrayFeedback._beep: tone selection ──────────────────────────────────
+
+
+def _make_feedback(player):
+    return feedback.TrayFeedback("ctrl+alt+l", player=player)
+
+
+def test_beep_success_like_plays_like_tone() -> None:
+    calls: list[bytes] = []
+    fb = _make_feedback(player=calls.append)
+
+    fb._beep(success=True, kind="like")
+
+    assert calls == [fb._tones["like"]]
+
+
+def test_beep_success_remove_plays_remove_tone() -> None:
+    calls: list[bytes] = []
+    fb = _make_feedback(player=calls.append)
+
+    fb._beep(success=True, kind="remove")
+
+    assert calls == [fb._tones["remove"]]
+
+
+def test_beep_failure_plays_error_tone_regardless_of_kind() -> None:
+    calls: list[bytes] = []
+    fb = _make_feedback(player=calls.append)
+
+    fb._beep(success=False, kind="remove")
+
+    assert calls == [fb._tones["error"]]
+
+
+# ── _play_tone: the real winsound seam ──────────────────────────────────
+#
+# Real `winsound.PlaySound` rejects `SND_MEMORY | SND_ASYNC` outright and
+# raises `RuntimeError: Cannot play asynchronously from memory` — every
+# beep crashed with this before 78f1e17. A fake winsound that reproduces
+# that check pins the fix: `_play_tone` must never pass the async flag.
+
+
+class _FakeWinsound:
+    SND_MEMORY = 4
+    SND_ASYNC = 1
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[bytes, int]] = []
+
+    def PlaySound(self, data: bytes, flags: int) -> None:
+        if flags & self.SND_ASYNC and flags & self.SND_MEMORY:
+            raise RuntimeError("Cannot play asynchronously from memory")
+        self.calls.append((data, flags))
+
+
+@pytest.fixture
+def fake_winsound(monkeypatch) -> _FakeWinsound:
+    fake = _FakeWinsound()
+    monkeypatch.setitem(sys.modules, "winsound", fake)
+    return fake
+
+
+def test_play_tone_uses_sync_memory_playback(fake_winsound) -> None:
+    feedback._play_tone(b"tonedata")
+
+    assert fake_winsound.calls == [(b"tonedata", fake_winsound.SND_MEMORY)]
+
+
+def test_play_tone_would_crash_if_async_flag_were_reintroduced(
+    fake_winsound,
+) -> None:
+    """Regression guard: pins the exact crash 78f1e17 fixed, so a future
+    edit that reintroduces SND_ASYNC fails loudly in CI instead of on
+    every user's first like."""
+    with pytest.raises(RuntimeError, match="Cannot play asynchronously"):
+        fake_winsound.PlaySound(
+            b"tonedata", fake_winsound.SND_MEMORY | fake_winsound.SND_ASYNC
+        )


### PR DESCRIPTION
## Summary

`TrayFeedback._beep`/`_synth_tone` were untested — exactly where the SND_ASYNC-from-memory crash (78f1e17) lived. `winsound` was imported lazily inside `_beep`, which made it awkward to mock (likely why the gap existed).

- Extracted an injectable seam: `TrayFeedback` now takes an optional `player: Callable[[bytes], None]` keyword arg (default `_play_tone`, which wraps `winsound.PlaySound(..., SND_MEMORY)`).
- `tests/test_feedback.py` covers:
  - `_synth_tone`/`_synth_tones` output shape (valid WAV header, volume scaling, distinct like/remove/error tones)
  - `_beep`'s tone selection per `(success, kind)`
  - `_play_tone`'s real `winsound` seam via a fake `winsound` module injected through `sys.modules`, including a regression guard that pins the exact `SND_MEMORY | SND_ASYNC` crash 78f1e17 fixed — so a future edit that reintroduces the async flag fails in CI instead of on a user's first like.

No behavior change to production code paths — `player` defaults to the same `winsound.PlaySound(..., SND_MEMORY)` call that was inline before.

## Test plan

- [x] `pytest tests/test_feedback.py tests/test_hosts.py -q` — 31 passed
- [x] `pytest -q` (full suite) — 189 passed (was 181 before this PR)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)