### PR TITLE
fix: share one _CooldownStore between like-cooldown gate and recorder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,7 +334,7 @@ Existing impls: `archive_remove`, `promote_to_best_of`, `follow_artist`.
 
 `archive_remove` reads its target playlist from
 `actions.archive_remove.playlist_name` in `config.json`; a blank name
-disables it (and `build_post_actions` drops the action). The same name
+disables it (and `build_action_chains` drops the action). The same name
 feeds the standalone **remove-without-like** flow: `RemoveFromPlaylistPipeline`
 (in `core/pipeline.py`) removes the currently-playing track from that
 playlist *without* a like. The Windows tray host binds it to a second

--- a/like_spotify/hosts/_common.py
+++ b/like_spotify/hosts/_common.py
@@ -169,76 +169,56 @@ def resolve_archive_playlist_name(cfg: dict) -> str:
     )
 
 
-def build_pre_actions(cfg: dict) -> list[PreLikeAction]:
-    """Compose the default-flavor pre-like chain.
+def _like_cooldown_pre_action(cfg: dict) -> tuple[PreLikeAction | None, PostLikeAction | None]:
+    """Build the like-cooldown gate + recorder from one shared `_CooldownStore`.
 
-    Currently just the like-cooldown gate — `actions.like_cooldown.minutes`
-    (default 10), opt-out via `actions.like_cooldown.enabled = false`.
-    Must be paired with `like_cooldown_post_action` on the *same* `Pipeline`
-    so the gate and the recorder share cooldown state.
-    """
-    actions: list[PreLikeAction] = []
-    nested = cfg.get("actions") if isinstance(cfg.get("actions"), dict) else {}
-    cooldown_cfg = (
-        nested.get("like_cooldown") if isinstance(nested.get("like_cooldown"), dict) else {}
-    )
-    if cooldown_cfg.get("enabled", True):
-        try:
-            gate, _recorder = build_like_cooldown(
-                LIKE_COOLDOWN_FILE,
-                minutes=int(cooldown_cfg.get("minutes", DEFAULT_LIKE_COOLDOWN_MINUTES)),
-            )
-            actions.append(gate)
-        except Exception:
-            pass
-    return actions
-
-
-def like_cooldown_post_action(cfg: dict) -> PostLikeAction | None:
-    """The recorder half of `build_pre_actions`'s cooldown gate.
-
-    Split into its own function (rather than folded into
-    `build_post_actions`) because pre- and post-actions are built and
-    passed to `Pipeline(...)` separately by every host; both must share the
-    same `_CooldownStore`, so this instantiates a *fresh* gate/recorder
-    pair and discards the gate — the recorder is the only piece missing
-    from `build_pre_actions`'s chain.
+    `actions.like_cooldown.minutes` (default 10), opt-out via
+    `actions.like_cooldown.enabled = false`. Both halves come from a single
+    `build_like_cooldown` call so the gate and recorder are structurally
+    coupled to the same store — see `build_action_chains`, the only caller.
     """
     nested = cfg.get("actions") if isinstance(cfg.get("actions"), dict) else {}
     cooldown_cfg = (
         nested.get("like_cooldown") if isinstance(nested.get("like_cooldown"), dict) else {}
     )
     if not cooldown_cfg.get("enabled", True):
-        return None
+        return None, None
     try:
-        _gate, recorder = build_like_cooldown(
+        return build_like_cooldown(
             LIKE_COOLDOWN_FILE,
             minutes=int(cooldown_cfg.get("minutes", DEFAULT_LIKE_COOLDOWN_MINUTES)),
         )
-        return recorder
     except Exception:
-        return None
+        return None, None
 
 
-def build_post_actions(
+def build_action_chains(
     cfg: dict, storage: Storage | None
-) -> list[PostLikeAction]:
-    """Compose the default-flavor post-like chain.
+) -> tuple[list[PreLikeAction], list[PostLikeAction]]:
+    """Compose the default-flavor pre- and post-like chains together.
 
-    Each action is independently togglable: omit / blank the relevant
-    config key OR set `actions.<name>.enabled = false` to skip it.
+    One function rather than separate `build_pre_actions`/`build_post_actions`
+    calls: the like-cooldown gate and recorder must share a single
+    `_CooldownStore` (see `_like_cooldown_pre_action`), and building the two
+    chains independently made that sharing an unenforced convention — nothing
+    stopped a caller from wiring one half onto the `Pipeline` without the
+    other. Every other action is independently togglable as before: omit /
+    blank the relevant config key OR set `actions.<name>.enabled = false`.
     """
-    actions: list[PostLikeAction] = []
+    pre_actions: list[PreLikeAction] = []
+    post_actions: list[PostLikeAction] = []
     nested = cfg.get("actions") if isinstance(cfg.get("actions"), dict) else {}
 
-    cooldown_recorder = like_cooldown_post_action(cfg)
+    cooldown_gate, cooldown_recorder = _like_cooldown_pre_action(cfg)
+    if cooldown_gate is not None:
+        pre_actions.append(cooldown_gate)
     if cooldown_recorder is not None:
-        actions.append(cooldown_recorder)
+        post_actions.append(cooldown_recorder)
 
     archive_name = resolve_archive_playlist_name(cfg)
     if archive_name:
         try:
-            actions.append(make_archive_remove_action(playlist_name=archive_name))
+            post_actions.append(make_archive_remove_action(playlist_name=archive_name))
         except Exception:
             pass
 
@@ -251,7 +231,7 @@ def build_post_actions(
     )
     if best_of_name and best_of_cfg.get("enabled", True):
         try:
-            actions.append(
+            post_actions.append(
                 make_promote_to_best_of_action(
                     playlist_name=best_of_name,
                     threshold=int(best_of_cfg.get("threshold", 3)),
@@ -265,7 +245,7 @@ def build_post_actions(
     follow_enabled = follow_cfg.get("enabled", True) and storage is not None
     if follow_enabled:
         try:
-            actions.append(
+            post_actions.append(
                 make_follow_artist_action(
                     storage=storage,
                     threshold=int(follow_cfg.get("threshold", 5)),
@@ -274,7 +254,7 @@ def build_post_actions(
         except Exception:
             pass
 
-    return actions
+    return pre_actions, post_actions
 
 
 def resolve_client_id(cfg: dict) -> str:

--- a/like_spotify/hosts/_stub.py
+++ b/like_spotify/hosts/_stub.py
@@ -96,8 +96,7 @@ def _run_like_once() -> int:
 
     feedback = CliFeedback()
     storage = _common.build_storage(cfg)
-    pre_actions = _common.build_pre_actions(cfg)
-    post_actions = _common.build_post_actions(cfg, storage)
+    pre_actions, post_actions = _common.build_action_chains(cfg, storage)
     pipeline = Pipeline(
         provider=provider,
         feedback=feedback,

--- a/like_spotify/hosts/windows/resident.py
+++ b/like_spotify/hosts/windows/resident.py
@@ -82,8 +82,7 @@ def _run_like_once() -> int:
 
     feedback = CliFeedback()
     storage = _common.build_storage(cfg)
-    pre_actions = _common.build_pre_actions(cfg)
-    post_actions = _common.build_post_actions(cfg, storage)
+    pre_actions, post_actions = _common.build_action_chains(cfg, storage)
     pipeline = Pipeline(
         provider=provider,
         feedback=feedback,
@@ -251,8 +250,7 @@ def _run_resident_host() -> int:
         hotkey=hotkey, volume=_common.resolve_feedback_volume(cfg)
     )
     storage = _common.build_storage(cfg)
-    pre_actions = _common.build_pre_actions(cfg)
-    post_actions = _common.build_post_actions(cfg, storage)
+    pre_actions, post_actions = _common.build_action_chains(cfg, storage)
     pipeline = Pipeline(
         provider=provider,
         feedback=feedback,

--- a/tests/test_action_chains.py
+++ b/tests/test_action_chains.py
@@ -1,0 +1,72 @@
+"""Tests for `hosts/_common.py`'s `build_action_chains` (issue #57).
+
+`build_pre_actions` and `build_post_actions` used to each independently call
+`build_like_cooldown`, constructing two separate `_CooldownStore` instances
+for the gate and the recorder. They happened to converge on the same JSON
+file, but nothing enforced that a caller wired both halves onto the same
+`Pipeline` — a future host could build one chain and forget the other.
+`build_action_chains` replaces both with a single call that returns the gate
+and recorder built from one shared store.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from like_spotify.core.types import CurrentTrack, LikeContext
+from like_spotify.hosts import _common
+
+
+def _ctx(track_id: str = "trk-a") -> LikeContext:
+    return LikeContext(
+        track=CurrentTrack(
+            provider="spotify",
+            provider_track_id=track_id,
+            title="Song",
+            artists=("Artist",),
+        )
+    )
+
+
+@pytest.fixture
+def cooldown_file(tmp_path, monkeypatch):
+    path = tmp_path / "like_cooldown.json"
+    monkeypatch.setattr(_common, "LIKE_COOLDOWN_FILE", path)
+    return path
+
+
+@pytest.mark.asyncio
+async def test_cooldown_gate_and_recorder_share_state(cooldown_file) -> None:
+    pre_actions, post_actions = _common.build_action_chains({}, storage=None)
+
+    gates = [a for a in pre_actions if type(a).__name__ == "LikeCooldownGate"]
+    recorders = [a for a in post_actions if type(a).__name__ == "LikeCooldownRecorder"]
+    assert len(gates) == 1
+    assert len(recorders) == 1
+
+    ctx = _ctx()
+    assert await gates[0].run(ctx) is True
+    await recorders[0].run(ctx)
+
+    # Same track, still inside the default 10-minute window — the gate
+    # built alongside the recorder must see what the recorder just wrote.
+    assert await gates[0].run(_ctx()) is False
+
+
+@pytest.mark.asyncio
+async def test_cooldown_disabled_omits_gate_and_recorder(cooldown_file) -> None:
+    cfg = {"actions": {"like_cooldown": {"enabled": False}}}
+
+    pre_actions, post_actions = _common.build_action_chains(cfg, storage=None)
+
+    assert not any(type(a).__name__ == "LikeCooldownGate" for a in pre_actions)
+    assert not any(type(a).__name__ == "LikeCooldownRecorder" for a in post_actions)
+
+
+def test_cooldown_minutes_respected(cooldown_file) -> None:
+    cfg = {"actions": {"like_cooldown": {"minutes": 30}}}
+
+    pre_actions, _post_actions = _common.build_action_chains(cfg, storage=None)
+
+    gate = next(a for a in pre_actions if type(a).__name__ == "LikeCooldownGate")
+    assert gate._window_seconds == 30 * 60


### PR DESCRIPTION
## Summary
- `build_pre_actions` and `build_post_actions` each independently called `build_like_cooldown`, constructing two separate `LikeCooldownGate`/`LikeCooldownRecorder` pairs. They happened to converge on the same JSON file (no in-memory cache), but nothing enforced both halves being wired onto the same `Pipeline` — a future host could forget one.
- Replace both with `build_action_chains(cfg, storage) -> (pre_actions, post_actions)`, which builds the cooldown gate + recorder from a single shared `build_like_cooldown` call.
- Updated all 3 call sites (`_stub.py`, `resident.py` x2) and `CONTRIBUTING.md`.

## Test plan
- [x] `tests/test_action_chains.py` (new) — gate/recorder share state, cooldown-disabled omits both, minutes config respected
- [x] `pytest -q` — 192 passed

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)