### PR TITLE
refactor(core): PlaylistCapableProvider protocol replaces duplicated duck-typing

### DIFF
--- a/like_spotify/core/music_provider.py
+++ b/like_spotify/core/music_provider.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Protocol, runtime_checkable
 
 from .types import CurrentTrack
 
@@ -31,3 +32,27 @@ class MusicProvider(ABC):
         Expected O(1) after setup (cached post-auth value). Async because
         a future provider may need a lazy fetch on first call.
         """
+
+
+@runtime_checkable
+class PlaylistCapableProvider(Protocol):
+    """Optional capability: named-playlist read/write + follow-artist.
+
+    Spotify-flavored extras that don't belong on the base `MusicProvider`
+    (per docs/design/interfaces.md §4.6 — stay at one flag until >=3 real
+    capability axes emerge; this is that first axis). Call sites that need
+    them check `isinstance(provider, PlaylistCapableProvider)` instead of
+    duplicating an `isinstance(provider, SpotifyMusicProvider)` or
+    `getattr(provider, "...", None)` probe each — `SpotifyMusicProvider`
+    satisfies this structurally, no inheritance required.
+    """
+
+    async def find_playlist_by_name(self, name: str) -> str | None: ...
+
+    async def get_playlist_track_ids(self, playlist_id: str) -> set[str]: ...
+
+    async def remove_track_from_playlist(
+        self, track_id: str, playlist_id: str
+    ) -> None: ...
+
+    async def follow_artist(self, artist_id: str) -> None: ...

--- a/like_spotify/core/pipeline.py
+++ b/like_spotify/core/pipeline.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from typing import Protocol
 
 from .actions import PostLikeAction, PreLikeAction
-from .music_provider import MusicProvider
+from .music_provider import MusicProvider, PlaylistCapableProvider
 from .storage import Storage
 from .types import CurrentTrack, LikeContext
 
@@ -138,10 +138,10 @@ class RemoveFromPlaylistPipeline:
     a separate Trigger wired here lets the user curate a playlist without
     liking the track.
 
-    Provider-agnostic by duck typing: it needs `get_currently_playing`
-    (on the `MusicProvider` base) plus `find_playlist_by_name` /
-    `remove_track_from_playlist` (Spotify-flavored extras, not on the
-    base). A provider lacking the playlist API gets a clean error
+    Provider-agnostic via `PlaylistCapableProvider`: it needs
+    `get_currently_playing` (on the `MusicProvider` base) plus
+    `find_playlist_by_name` / `remove_track_from_playlist` (the optional
+    playlist capability). A provider lacking it gets a clean error
     feedback rather than an exception — keeping `core` free of any
     extension import.
 
@@ -181,9 +181,7 @@ class RemoveFromPlaylistPipeline:
             self._feedback(False, "Nothing playing", "", kind="remove")
             return
 
-        finder = getattr(self._provider, "find_playlist_by_name", None)
-        remover = getattr(self._provider, "remove_track_from_playlist", None)
-        if finder is None or remover is None:
+        if not isinstance(self._provider, PlaylistCapableProvider):
             self._feedback(
                 False,
                 "Remove unsupported",
@@ -194,7 +192,9 @@ class RemoveFromPlaylistPipeline:
 
         if self._playlist_id is None:
             try:
-                self._playlist_id = await finder(self._playlist_name)
+                self._playlist_id = await self._provider.find_playlist_by_name(
+                    self._playlist_name
+                )
             except Exception as e:
                 # Not cached — next press retries.
                 self._feedback(
@@ -208,7 +208,9 @@ class RemoveFromPlaylistPipeline:
                 return
 
         try:
-            await remover(track.provider_track_id, self._playlist_id)
+            await self._provider.remove_track_from_playlist(
+                track.provider_track_id, self._playlist_id
+            )
         except Exception as e:
             # The cached id may be stale (playlist deleted/renamed since the
             # last resolve) — drop it so the next press re-resolves instead

--- a/like_spotify/extensions/archive_remove/__init__.py
+++ b/like_spotify/extensions/archive_remove/__init__.py
@@ -22,8 +22,8 @@ import logging
 
 from like_spotify.core.actions import PostLikeAction
 from like_spotify.core.errors import AuthError
+from like_spotify.core.music_provider import PlaylistCapableProvider
 from like_spotify.core.types import LikeContext
-from like_spotify.extensions.spotify import SpotifyMusicProvider
 
 DOMAIN = "archive_remove"
 
@@ -45,8 +45,8 @@ class ArchiveRemoveAction(PostLikeAction):
 
     async def run(self, ctx: LikeContext) -> None:
         provider = ctx.music_provider
-        if not isinstance(provider, SpotifyMusicProvider):
-            # Other flavours don't speak Spotify playlist API. Silent no-op.
+        if not isinstance(provider, PlaylistCapableProvider):
+            # Other flavours don't speak the playlist capability. Silent no-op.
             return
 
         if not self._resolved:
@@ -65,7 +65,7 @@ class ArchiveRemoveAction(PostLikeAction):
         # Update local snapshot so a re-trigger in the same session stays no-op.
         self._track_ids.discard(track_id)
 
-    async def _resolve(self, provider: SpotifyMusicProvider) -> None:
+    async def _resolve(self, provider: PlaylistCapableProvider) -> None:
         self._resolved = True
         try:
             pid = await provider.find_playlist_by_name(self._playlist_name)

--- a/like_spotify/extensions/follow_artist/__init__.py
+++ b/like_spotify/extensions/follow_artist/__init__.py
@@ -20,9 +20,9 @@ import logging
 
 from like_spotify.core.actions import PostLikeAction
 from like_spotify.core.errors import AuthError
+from like_spotify.core.music_provider import PlaylistCapableProvider
 from like_spotify.core.storage import Storage
 from like_spotify.core.types import LikeContext
-from like_spotify.extensions.spotify import SpotifyMusicProvider
 
 DOMAIN = "follow_artist"
 DEFAULT_THRESHOLD = 5
@@ -41,7 +41,7 @@ class FollowArtistAction(PostLikeAction):
 
     async def run(self, ctx: LikeContext) -> None:
         provider = ctx.music_provider
-        if not isinstance(provider, SpotifyMusicProvider):
+        if not isinstance(provider, PlaylistCapableProvider):
             return
         artist_ids = ctx.track.artist_ids
         if not artist_ids:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -474,6 +474,12 @@ class FakeRemoveProvider(MusicProvider):
         ):
             raise self._remove_raises
 
+    async def get_playlist_track_ids(self, playlist_id: str) -> set[str]:  # pragma: no cover
+        raise AssertionError("remove flow does not need track-id membership")
+
+    async def follow_artist(self, artist_id: str) -> None:  # pragma: no cover
+        raise AssertionError("remove flow does not follow artists")
+
 
 @pytest.mark.asyncio
 async def test_remove_pipeline_removes_current_track_without_liking() -> None:


### PR DESCRIPTION
## Summary

- `RemoveFromPlaylistPipeline.run_once` (`core/pipeline.py`), `ArchiveRemoveAction`, and `FollowArtistAction` each independently duck-typed the Spotify-flavored playlist/follow API — two via `isinstance(provider, SpotifyMusicProvider)`, one via `getattr(provider, "find_playlist_by_name", None)`. Same check, three copies.
- Adds `PlaylistCapableProvider`, a `runtime_checkable` `Protocol` in `core/music_provider.py` covering `find_playlist_by_name`, `get_playlist_track_ids`, `remove_track_from_playlist`, `follow_artist`. `SpotifyMusicProvider` satisfies it structurally — no changes to its public methods.
- All three call sites now check `isinstance(provider, PlaylistCapableProvider)` against the shared seam.
- `MusicProvider` itself is unchanged — additive capability-detection Protocol, not a widened base interface, per `docs/design/interfaces.md` §4.6 ("stay at one flag until ≥3 real capability axes emerge — this is that first axis").
- `promote_to_best_of`'s own `isinstance(provider, SpotifyMusicProvider)` check is intentionally left alone — it's not one of the three call sites named in #59.

Closes #59

## Test plan

- [x] `python -m pytest -q` → 192 passed, zero regressions
- [x] `ruff check` on all changed files → clean
- [x] Updated `FakeRemoveProvider` in `tests/test_pipeline.py` with stub `get_playlist_track_ids`/`follow_artist` so it validly satisfies the full Protocol (it previously only implemented the 2 of 4 methods the remove flow actually calls, under the old per-method `getattr` check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)